### PR TITLE
Fix broken install on Mac OS X

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ibm_db",
   "description": "IBM DB2 and IBM Informix bindings for node",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "lib/odbc.js",
   "homepage": "http://github.com/ibmdb/node-ibm_db/",
   "repository": {
@@ -28,9 +28,9 @@
   "dependencies": {
     "bindings": "~1.0.0",
     "nan": "~1.8.*",
-    "unzip": "*",
-    "tar.gz": "*",
-    "fstream": "*"
+    "unzip": "^0.1.11",
+    "tar.gz": "^0.1.1",
+    "fstream": "^1.0.7"
   },
   "keywords": [
     "node",


### PR DESCRIPTION
The npm tar.gz package was updated ~15 hours ago and breaks install on Mac OS X