### PR TITLE
Replace usage of `timelocal` with `mktime`

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -522,7 +522,7 @@ Handle<Value> ODBC::GetColumnValue( SQLHSTMT hStmt, Column column,
         return NanEscapeScope(NanNew<Date>((double(timegm(&timeInfo)) * 1000)
                           + (odbcTime.fraction / 1000000)));
 #else
-        return NanEscapeScope(NanNew<Date>((double(timelocal(&timeInfo)) * 1000)
+        return NanEscapeScope(NanNew<Date>((double(mktime(&timeInfo)) * 1000)
                           + (odbcTime.fraction / 1000000)));
 #endif
         //return Date::New((double(timegm(&timeInfo)) * 1000) 


### PR DESCRIPTION
`timelocal` is a non-standard alias for `mktime`. Since it's non-standard, it doesn't exist in some implementations of `time.h` depending on the flavor of C in use, platform, etc. Changing it to `mktime` fixes compilation issues on some platforms (e.g. Alpine Linux).

Fixes #72.

More info: http://linux.die.net/man/3/timelocal

**Excerpt**
```
The timelocal() function is equivalent to the POSIX standard function mktime(3). There is no reason to ever use it.
```