### PR TITLE
Feature for issue #93

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -790,8 +790,15 @@ module.exports.Pool = Pool;
 
 Pool.count = 0;
 
-function Pool () {
+function Pool (_options) {
   var self = this;
+	self.options = {};
+	if(_options) {
+		if(_options.idleTimeout && !isNaN(_options.idleTimeout))
+			self.options.idleTimeout=_options.idleTimeout;
+		if(_options.autoCleanIdle)
+			self.options.autoCleanIdle=_options.autoCleanIdle;
+	}
   self.index = Pool.count++;
   self.availablePool = {};
   self.usedPool = {};
@@ -809,6 +816,7 @@ Pool.prototype.open = function (connStr, callback)
   if (self.availablePool[connStr] && self.availablePool[connStr].length) 
   {
     db = self.availablePool[connStr].shift()
+		db.lastUsed=null;
     self.usedPool[connStr].push(db)
     callback(null, db);
   }
@@ -820,6 +828,7 @@ Pool.prototype.open = function (connStr, callback)
           "odbc.js : pool[%s] : pool.db.open callback()", self.index);
 
       self.usedPool[connStr] = self.usedPool[connStr] || [];
+			db.created = Date.now();
       self.usedPool[connStr].push(db);
 
       callback(error, db);
@@ -828,6 +837,7 @@ Pool.prototype.open = function (connStr, callback)
     db.realClose = db.close;
     db.close = function (cb) 
     {
+			db.lastUsed = Date.now();
       //call back early, we can do the rest of this stuff after the client 
       //thinks that the connection is closed.
       cb(null);
@@ -847,13 +857,31 @@ Pool.prototype.open = function (connStr, callback)
       if(db.conn)
       {
         self.availablePool[connStr] = self.availablePool[connStr] || [];
-        self.availablePool[connStr].push(db);
+        self.availablePool[connStr].unshift(db);
+				
+				//start cleanUp if enabled
+				if(self.options.autoCleanIdle)self.cleanUp(connStr);
       }
       exports.debug && console.dir(self);
     };  // db.close function
     
   }
 };
+
+// Close idle connections
+Pool.prototype.cleanUp = function(connStr,callback) {
+	var self = this;
+	if(self.availablePool[connStr].length==1) return;
+	self.availablePool[connStr]=self.availablePool[connStr].filter(function(conn) {
+		if(conn.lastUsed && (Date.now()-conn.lastUsed > (self.options.idleTimeout || 1800 * 1000)) && conn.realClose ) {
+			 conn.realClose(function() {
+				 exports.debug && console.log("odbc.js : pool[%s] : Pool.cleanUp() : pool.realClose() : Connection duration : %s", self.index, (Date.now() - conn.created)/1000);
+			 })
+			 return false;
+		}
+		else return true;
+	})
+} //Pool.cleanUp()
 
 Pool.prototype.close = function (callback) 
 {
@@ -935,4 +963,3 @@ Pool.prototype.close = function (callback)
     } //for (key in pools)
   }, 2000);  //setTimeout
 };  //Pool.close()
-


### PR DESCRIPTION
New feature to close Unused/Idle Pool connections.

- Extended Pool with an options object in order to optionally provide `idleTimeout` (default 180 seconds) and `autoCleanIdle` (default null/false). 
- Each connection now has a `created` and `lastUsed` value (timestamps). 
- Modified `db.open()` to reset `lastUsed` value.
- Modified `db.close()` to set a `lastUsed` value, also to invoke `cleanUp` function if `autoCleanIdle` is enabled.
- `cleanUp` function checks `availablePools` if the `lastUsed` value is older than `idleTimeout`, if so the connection is closed and removed from `availablePools`
- Replaced push to unshift (queue to stack) in `db.open()` to avoid rotation of all connections; to increase efficiency of `cleanUp`