### PR TITLE
Installer behind proxy with basic authentication

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -316,6 +316,12 @@ var download_file_httpget = function(file_url) {
                              port: url.parse(proxyStr.toString()).port,
                              path: url.parse(installerfileURL).href
                             };
+                            
+                            if (proxyConfig.auth) {
+                                options.headers: {
+                                 'Proxy-Authorization': 'Basic ' + new Buffer(proxyConfig.auth).toString('base64')
+                                }
+                            }
                         }
                     }
                     return http.get(options, downloadCLIDriver); 
@@ -324,12 +330,19 @@ var download_file_httpget = function(file_url) {
             {
                 var splitIndex = proxyStr.toString().lastIndexOf(':');
                 if(splitIndex > 0) {
-                            
+                    
+                    var proxyConfig = url.parse(proxyStr.toString());
                     options = {
-                     host: url.parse(proxyStr.toString()).hostname,
-                     port: url.parse(proxyStr.toString()).port,
-                     path: url.parse(installerfileURL).href
+                     host: proxyConfig.hostname,
+                     port: proxyConfig.port,
+                     path: url.parse(installerfileURL).href,
                     };
+
+                    if (proxyConfig.auth) {
+                        options.headers: {
+                         'Proxy-Authorization': 'Basic ' + new Buffer(proxyConfig.auth).toString('base64')
+                        }
+                    }                    
                 }
                 return http.get(options, downloadCLIDriver); 
             }

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -156,7 +156,7 @@ var download_file_httpget = function(file_url) {
     {
         if( res.statusCode != 200 ) 
         {
-            log( "Unable to download IBM ODBC and CLI Driver from " +
+            console.log( "Unable to download IBM ODBC and CLI Driver from " +
                   installerfileURL );
             process.exit(1);
         }
@@ -168,7 +168,7 @@ var download_file_httpget = function(file_url) {
         res.on('data', function(data) {
             if( byteIndex + data.length > buf.length ) 
             {
-                log( "Error downloading IBM ODBC and CLI Driver from " +
+                console.log( "Error downloading IBM ODBC and CLI Driver from " +
                      installerfileURL );
                 process.exit(1);
             }
@@ -177,7 +177,7 @@ var download_file_httpget = function(file_url) {
          }).on('end', function() {
              if( byteIndex != buf.length ) 
              {
-                log( "Error downloading IBM ODBC and CLI Driver from " +
+                console.log( "Error downloading IBM ODBC and CLI Driver from " +
                      installerfileURL );
                 process.exit(1);
              }
@@ -185,7 +185,7 @@ var download_file_httpget = function(file_url) {
              var len = fs.writeSync( file, buf, 0, buf.length, 0 );
              if( len != buf.length ) 
              {
-                log( "Error writing IBM ODBC and CLI Driver to a file" );
+                console.log( "Error writing IBM ODBC and CLI Driver to a file" );
                 process.exit(1);
              }
              fs.closeSync( file );

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -318,7 +318,7 @@ var download_file_httpget = function(file_url) {
                             };
                             
                             if (proxyConfig.auth) {
-                                options.headers: {
+                                options.headers = {
                                  'Proxy-Authorization': 'Basic ' + new Buffer(proxyConfig.auth).toString('base64')
                                 }
                             }
@@ -339,7 +339,7 @@ var download_file_httpget = function(file_url) {
                     };
 
                     if (proxyConfig.auth) {
-                        options.headers: {
+                        options.headers = {
                          'Proxy-Authorization': 'Basic ' + new Buffer(proxyConfig.auth).toString('base64')
                         }
                     }                    


### PR DESCRIPTION
Hi,

I had to run this installer behind a proxy with basic authentication.
Realized the request headers were not set properly, so I went ahead, forked the repository and performed the necessary changes.

Also, the proxy exceptions were not being thrown given '''log(String)''' is an nonexistent function.

Hope this can be helpful.