### PR TITLE
Fix driver download when using https proxy by adding Host header

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -344,9 +344,12 @@ var download_file_httpget = function(file_url) {
                         {
                             var proxyUrl = url.parse(proxyStr.toString());
                             options = {
-                             host: proxyUrl.hostname,
-                             port: proxyUrl.port,
-                             path: url.parse(installerfileURL).href
+                                host: proxyUrl.hostname,
+                                port: proxyUrl.port,
+                                path: url.parse(installerfileURL).href,
+                                headers: {
+                                    Host: url.parse(installerfileURL).hostname
+                                }
                             };
                             if (proxyUrl.auth) 
                             {
@@ -363,9 +366,12 @@ var download_file_httpget = function(file_url) {
                 if(splitIndex > 0) {
                     var proxyUrl = url.parse(proxyStr.toString());
                     options = {
-                     host: proxyUrl.hostname,
-                     port: proxyUrl.port,
-                     path: url.parse(installerfileURL).href
+                        host: proxyUrl.hostname,
+                        port: proxyUrl.port,
+                        path: url.parse(installerfileURL).href,
+                        headers: {
+                            Host: url.parse(installerfileURL).hostname
+                        }
                     };
                     if (proxyUrl.auth) 
                     {


### PR DESCRIPTION
Driver download was failing on RHEL6 with node v0.12 (cannot run newer due to old version of gcc). Added Host header to the request fixed the issue.

Might fix what @josiah14 was dealing with in #111