### PR TITLE
force test-call-stmt and test-call-async to use the default schema

### DIFF
--- a/test/test-call-async.js
+++ b/test/test-call-async.js
@@ -4,21 +4,21 @@
 var common = require("./common")
   , ibmdb = require("../")
   , assert = require("assert")
-  , cn = common.connectionString;
+  , cn = common.connectionString
+  , schema = common.connectionObject.CURRENTSCHEMA;
 
-var query = "CaLL newton.proc1(?, ?, ?)";
-ibmdb.open(cn, function (err, conn) 
+ibmdb.open(cn, function (err, conn)
 {
+    var query = "CaLL " + schema + ".proc1(?, ?, ?)";
     if(err) return console.log(err);
     try {
-          conn.querySync("drop procedure newton.proc1");
-          console.log("newton.proc1 dropped.\n");
+          conn.querySync("drop procedure " + schema + ".proc1");
+          console.log("proc1 dropped.\n");
     } catch(e) {}
-
-    conn.querySync("create procedure newton.proc1 " +
+    conn.querySync("create procedure " + schema + ".proc1 " +
                    "(IN v1 INTEGER, OUT v2 INTEGER, INOUT v3 VARCHAR(20)) " +
                    "BEGIN set v2 = v1 + 1; set v3 = 'verygood'; END");
-    console.log("created newton.proc1...\n");
+    console.log("created proc1...\n");
     conn.commitTransactionSync();
     var param1 = {ParamType:"INPUT", DataType:1, Data:3};
     var param2 = {ParamType:"OUTPUT", DataType:1, Data:0};
@@ -29,17 +29,16 @@ ibmdb.open(cn, function (err, conn)
         else {
             console.log("return value = ", result[0], result[1]);
         }
-        conn.querySync("drop procedure newton.proc1");
+        conn.querySync("drop procedure " + schema + ".proc1");
         conn.closeSync();
         assert.deepEqual(result, [ 4, 'verygood' ]);
     });
-    conn.querySync("create or replace procedure proc2 (IN v1 INTEGER) BEGIN END");
-    conn.query("call proc2(?)", [param1], function(err, result){
+    conn.querySync("create or replace procedure " + schema + ".proc2 (IN v1 INTEGER) BEGIN END");
+    conn.query("call " + schema + ".proc2(?)", [param1], function(err, result){
         if(err) console.log(err);
-        conn.querySync("drop procedure proc2");
+        conn.querySync("drop procedure " + schema + ".proc2");
         conn.closeSync();
         assert.equal(result, true);
         console.log('done');
     });
 });
-

--- a/test/test-call-stmt.js
+++ b/test/test-call-stmt.js
@@ -3,17 +3,18 @@
 var common = require("./common")
   , ibmdb = require("../")
   , assert = require("assert")
-  , cn = common.connectionString;
+  , cn = common.connectionString
+  , schema = common.connectionObject.CURRENTSCHEMA;
 
-var query = "CaLL newton.proc1(?, ?, ?)";
-ibmdb.open(cn, function (err, conn) 
+var query = "CaLL " + schema + ".proc1(?, ?, ?)";
+ibmdb.open(cn, function (err, conn)
 {
     if(err) return console.log(err);
     try {
-          conn.querySync("drop procedure newton.proc1");
+          conn.querySync("drop procedure " + schema + ".proc1");
     } catch(e) {}
 
-    conn.querySync("create or replace procedure newton.proc1 " +
+    conn.querySync("create or replace procedure " + schema + ".proc1 " +
                    "(IN v1 INTEGER, OUT v2 INTEGER, INOUT v3 VARCHAR(20)) " +
                    "BEGIN set v2 = v1 + 1; set v3 = 'verygood'; END");
     var param1 = {ParamType:"INPUT", DataType:1, Data:3};
@@ -24,12 +25,11 @@ ibmdb.open(cn, function (err, conn)
     assert.deepEqual(result, [ 4, 'verygood' ]);
     console.log("Output Parameters V2 = ", result[0], ", V3 = ", result[1]);
 
-    conn.querySync("drop procedure newton.proc1");
-    conn.querySync("create or replace procedure newton.proc2 (IN v1 INTEGER) BEGIN END");
-    result = conn.querySync("call newton.proc2(?)", [param1]);
+    conn.querySync("drop procedure " + schema + ".proc1");
+    conn.querySync("create or replace procedure " + schema + ".proc2 (IN v1 INTEGER) BEGIN END");
+    result = conn.querySync("call " + schema + ".proc2(?)", [param1]);
     assert.equal(result, true);
-    conn.querySync("drop procedure newton.proc2");
+    conn.querySync("drop procedure " + schema + ".proc2");
     conn.closeSync();
     console.log('done');
 });
-


### PR DESCRIPTION
This fix means that the procedures are created using the correct schema