### PR TITLE
fix test-querySync-select-with-exception.js on windows

### DIFF
--- a/test/test-querySync-select-with-exception.js
+++ b/test/test-querySync-select-with-exception.js
@@ -13,13 +13,12 @@ try {
 }
 catch (e) {
   console.log(e);
-  
+
   err = e;
 }
 
 db.closeSync();
 if( /^win/.test(process.platform) )
-  assert.equal(err.error, "[node-odbc] Error in ODBCConnection::QuerySync while executing query.");
+  assert.equal(err.error, "[node-odbc] Error in ODBCConnection::QuerySync");
 else
   assert.equal(err.error, "[node-ibm_db] Error in ODBCConnection::QuerySync while executing query.");
-


### PR DESCRIPTION
The error is different on windows: `"[node-odbc] Error in ODBCConnection::QuerySync"`
