### PR TITLE
Implement a Readable stream on top of queryResults

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -27,6 +27,7 @@ if(os.platform() == 'win32')
 var odbc = require("bindings")("odbc_bindings")
   , SimpleQueue = require("./simple-queue")
   , util = require("util")
+  , Readable = require('stream').Readable
   , Q = require('q');
 
 
@@ -465,6 +466,41 @@ Database.prototype.queryResult = function (sql, params, cb)
     } // function cbQuery
   }); //self.queue.push
 }; // Database.queryResult
+
+Database.prototype.queryStream = function queryStream(sql, params) {
+  var self = this;
+  var stream = new Readable({ objectMode: true });
+  var results;
+  stream._read = function _readOrCreateQueryStream() {
+    // after the first internal call to _read, the 'results' should be set
+    // and the stream can continue fetching the results
+    if (results) return self._fetchStreamingResults(results, stream);
+    // in the first call to _read the stream starts to emit data once we've queried for results
+    return self.queryResult(sql, params, function (err, result) {
+      if (err) return process.nextTick(function () {
+        stream.emit('error', err);
+      });
+      results = result;
+      return self._fetchStreamingResults(results, stream);
+    });
+  };
+  return stream;
+};
+
+Database.prototype._fetchStreamingResults = function _fetchStreamingResults(results, stream) {
+  var self = this;
+  return results.fetch(function (err, data) {
+    if (err) return process.nextTick(function () {
+        stream.emit('error', err);
+    });
+    // when no more data returns, return push null to indicate the end of stream
+    if (!data) return stream.push(null);
+    // if pushing the data returns 'true', that means we can query and push more immediately
+    // othewise the _read function will be called again (executing this function)
+    // once the reading party is ready to recieve more
+    if (stream.push(data)) return self._fetchStreamingResults(results, stream);
+  });
+};
 
 Database.prototype.queryResultSync = function (sql, params)
 {

--- a/test/test-queryStream-error.js
+++ b/test/test-queryStream-error.js
@@ -1,0 +1,17 @@
+var common = require("./common")
+  , odbc = require("../")
+  , db = new odbc.Database()
+  , assert = require("assert")
+  ;
+
+db.openSync(common.connectionString);
+assert.equal(db.connected, true);
+
+var stream = db.queryStream("🐌");
+// adding the 'data' eventhandler starts the stream
+stream.once('data', function (data) {
+  throw new Error('data should not return from an erroring queryStream');
+}).once('error', function (err) {
+  assert.equal(err.state, '42601');
+  db.closeSync();
+});

--- a/test/test-queryStream-select.js
+++ b/test/test-queryStream-select.js
@@ -1,0 +1,17 @@
+var common = require("./common")
+  , odbc = require("../")
+  , db = new odbc.Database()
+  , assert = require("assert")
+  ;
+
+db.openSync(common.connectionString);
+assert.equal(db.connected, true);
+var stream = db.queryStream("select 1 as COLINT, 'some test' as COLTEXT FROM SYSIBM.SYSDUMMY1");
+stream.once('data', function (data) {
+  assert.deepEqual(data, { COLINT: '1', COLTEXT: 'some test' });
+}).once('error', function (err) {
+  db.closeSync();
+  throw err;
+}).once('end', function () {
+  db.closeSync();
+});


### PR DESCRIPTION
I implemented a node.js [Readable stream](https://nodejs.org/dist/latest-v6.x/docs/api/stream.html#stream_implementing_a_readable_stream) on top of the undocumented `queryResults` interface.
