### PR TITLE
Fix up no results code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 deps
 defect
 .DS_Store
-
+build.zip
+installer/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ node_modules
 deps
 defect
 .DS_Store
-build.zip
-installer/*

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -324,7 +324,12 @@ Database.prototype.query = function (sql, params, cb)
   self.queue.push(function (next) {
     function cbQuery (initialErr, result)
     {
-      fetchMore();
+      if (typeof(result) === 'object') {
+        fetchMore();
+      } else {
+        cb(initialErr, [], false);
+        return next();
+      }
 
       function fetchMore()
       {


### PR DESCRIPTION
If result returned from query has is not an object then we shouldn't be attempting to call fetchAll on it.  This change will return the initialError, an empty array and false if result is not an object.  There are also changes to .gitignore to hide files that are changed as part of npm install