### PR TITLE
Add setIsolationLevel function

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -813,6 +813,11 @@ Database.prototype.prepareSync = function (sql, cb)
   return stmt;
 }
 
+Database.prototype.setIsolationLevel = function(isolationLevel) {
+  var self = this;
+  return (self.conn.setIsolationLevel(isolationLevel));
+}
+
 //Proxy all of the asynchronous functions so that they are queued
 odbc.ODBCStatement.prototype._execute = odbc.ODBCStatement.prototype.execute;
 odbc.ODBCStatement.prototype._executeDirect = odbc.ODBCStatement.prototype.executeDirect;

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -72,6 +72,8 @@ void ODBCConnection::Init(v8::Handle<Object> exports) {
   Nan::SetPrototypeMethod(constructor_template, "beginTransactionSync", BeginTransactionSync);
   Nan::SetPrototypeMethod(constructor_template, "endTransaction", EndTransaction);
   Nan::SetPrototypeMethod(constructor_template, "endTransactionSync", EndTransactionSync);
+
+  Nan::SetPrototypeMethod(constructor_template, "setIsolationLevel", SetIsolationLevel);
   
   Nan::SetPrototypeMethod(constructor_template, "columns", Columns);
   Nan::SetPrototypeMethod(constructor_template, "tables", Tables);
@@ -1651,4 +1653,48 @@ void ODBCConnection::UV_AfterEndTransaction(uv_work_t* req, int status) {
   
   free(data);
   free(req);
+}
+
+/*
+ * SetIsolationLevel
+ * 
+ */
+
+NAN_METHOD(ODBCConnection::SetIsolationLevel) {
+  DEBUG_PRINTF("ODBCConnection::SetIsolationLevel\n");
+  Nan::HandleScope scope;
+
+  ODBCConnection* conn = Nan::ObjectWrap::Unwrap<ODBCConnection>(info.Holder());
+
+  OPT_INT_ARG(0, isolationLevel, SQL_TXN_READ_COMMITTED)
+
+  Local<Value> objError;
+  SQLRETURN ret;
+  bool error = false;
+
+  //set the connection manual commits
+  ret = SQLSetConnectAttr(
+    conn->m_hDBC,
+    SQL_ATTR_TXN_ISOLATION,
+    (SQLPOINTER) isolationLevel,
+    SQL_NTS);
+
+  DEBUG_PRINTF("ODBCConnection::SetIsolationLevel isolationLevel=%d; ret=%d\n",
+               isolationLevel, ret);
+
+  //check how the transaction went
+  if (!SQL_SUCCEEDED(ret)) {
+    error = true;
+
+    objError = ODBC::GetSQLError(SQL_HANDLE_DBC, conn->m_hDBC);
+  }
+
+  if (error) {
+    Nan::ThrowError(objError);
+
+    info.GetReturnValue().Set(Nan::False());
+  }
+  else {
+    info.GetReturnValue().Set(Nan::True());
+  }
 }

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -91,6 +91,7 @@ class ODBCConnection : public Nan::ObjectWrap {
     static NAN_METHOD(CallSync);
     static NAN_METHOD(BeginTransactionSync);
     static NAN_METHOD(EndTransactionSync);
+    static NAN_METHOD(SetIsolationLevel);
     
     struct Fetch_Request {
       Nan::Callback* callback;


### PR DESCRIPTION
The code included in this PR adds setIsolationLevel on the connection object for better concurrency control in transactions.
