### PR TITLE
Fixed: Whitespace escape

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -264,7 +264,7 @@ var download_file_httpget = function(file_url) {
                             'CLI Driver completed successfully ...');
                 console.log(license_agreement);
                 IBM_DB_HOME = path.resolve(DOWNLOAD_DIR, 'clidriver');
-                process.env.IBM_DB_HOME = IBM_DB_HOME;
+                process.env.IBM_DB_HOME = IBM_DB_HOME.replace(/\s/g,'\\ ');
                 buildBinary(true);
                 removeWinBuildArchive();
               }


### PR DESCRIPTION
If the IBM_DB_HOME path had a directory that contained a whitespace character it was not being escaped and the install would fail.

I added some regex to replace any whitespace in the install path.

`IBM_DB_HOME.replace(/\s/g,'\\ ');`

I had opened this issue for this #200 