### PR TITLE
typeof NULL is object causing tests to fail

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -330,7 +330,7 @@ Database.prototype.query = function (query, params, cb)
         resultset = outparams;
         multipleResultSet = true;
       }
-      if (typeof(result) === 'object') {
+      if (result && typeof(result) === 'object') {
         fetchMore();
       } else {
         cb(initialErr, resultset);


### PR DESCRIPTION
typeof NULL is 'object' and with the latest ibm_db version if the user passes in noResultObject we are returning null instead of an undefined value.  This fix checks if result is null prior to checking the type of what is returned.