### PR TITLE
Corrects variable in openSync sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ var ibmdb = require("ibm_db"),
 
 try {
       var option = { connectTimeout : 40, systemNaming : true };// Connection Timeout after 40 seconds.
-      var conn = ibmdb.openSync(connString, option);
+      var conn = ibmdb.openSync(cn, option);
       conn.query("select * from customers fetch first 10 rows only", function (err, rows) {
 		if (err) {
 			console.log(err);


### PR DESCRIPTION
In the `.openSync` example the connection string variable is created as `cn` but called as `connString`. Changes the call to `cn` since the other sync functions use `cn` as the variable name.