### PR TITLE
Fix parameters when executing statements without a callback

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -1021,7 +1021,7 @@ odbc.ODBCStatement.prototype.execute = function (params, cb)
 
   self.queue = self.queue || new SimpleQueue();
 
-  if (!cb)
+  if (!cb && typeof params === 'function')
   {
     cb = params;
     params = null;


### PR DESCRIPTION
If no callback is given then a promise is returned, however if no callback is set the parameters get set to null. 
This commit makes it so before assuming the first argument is a callback it first checks if it is a function.