### PR TITLE
z/OS port of ibm_db

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An asynchronous/synchronous interface for node.js to IBM DB2 and IBM Informix.
 
-**Supported Platforms** - Windows64, MacOS64, Linuxx64, Linuxia32, AIX, Linux on z and Linux on Power PC.
+**Supported Platforms** - Windows64, MacOS64, Linuxx64, Linuxia32, AIX, Linux on IBM Z, Linux on Power PC and z/OS.
 
 ## Prerequisite
 
@@ -12,7 +12,9 @@ Install a newer compiler or upgrade older one.
 
 - Python 2.7 is needed by node-gyp.
 
-- You need not to install any db2 ODBC client driver for connectivity. `ibm_db` itself download and install odbc/cli driver from ibm website during installation. Just install `ibm_db` and it is ready for use.
+- On distributed platforms, you do need not to install any Db2 ODBC client driver for connectivity. `ibm_db` itself downloads and installs an odbc/cli driver from IBM website during installation. Just install `ibm_db` and it is ready for use.
+
+- On z/OS, ODBC driver support is part of IBM Db2 for z/OS 11.0 and 12.0.  Please ensure IBM Db2 for z/OS 11.0 or 12.0 is installed on your given LPAR.  Ensure you follow the instructions to configure your ODBC driver [here](#configure-odbc-driver-on-z/os).
 
 - Recommended versions of node.js is V4.x, V6.x and V7.x. Support for node.js V0.12.x is deprecated on Windows and will be discontinued from next release.
 
@@ -31,18 +33,25 @@ npm install ibm_db
 
 `IBM_DB_HOME :`
 
-- USE: Set this environment variable if you want to avoid downloading of clidriver from the [IBM Hosted URL](#downloadCli) or from the internet.
+- USE:
+	- On distributed platforms, set this environment variable if you want to avoid downloading of clidriver from the [IBM Hosted URL](#downloadCli) or from the internet.
+	- On z/OS, set this environment variable to the High Level Qualifier (HLQ) of your Db2 datasets. During `npm install`, the module will automatically reference ODBC driver header files under: `$IBM_DB_HOME.SDSNC.H` and the sidedeck definitions in `$IBM_DB_HOME.SDSNMACS(DSNAO64C)` to build the node binding.
 
-- How: Set **IBM_DB_HOME** environment variable to a pre-installed **db2 client or server installation directory**.
+- HOW:
+	- On distributed platforms, set **IBM_DB_HOME** environment variable to a pre-installed **db2 client or server installation directory**.
+	- On z/OS, set **IBM_DB_HOME** environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSN1210.SDSNC.H` and `DSN1210.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSN1210` with the following statement (can be saved in `~/.profile`):
+
 
 `IBM_DB_INSTALLER_URL :`
 
-- USE: Set this environment variable to by-pass the IBM Hosted URL for downloading odbc/clidriver.
+- USE:
+	- Set this environment variable to by-pass the IBM Hosted URL for downloading odbc/clidriver.
 
-- HOW: Set **IBM_DB_INSTALLER_URL** environment variable with alternate odbc/clidriver downloading URL link or with locally downloaded "tar/zipped clidriver's parent directory path.
+- HOW:
+	- Set **IBM_DB_INSTALLER_URL** environment variable with alternate odbc/clidriver downloading URL link or with locally downloaded "tar/zipped clidriver's parent directory path.
 
-- TIP: If you don't have alternate hosting URL then, you can download the tar/zipped file of clidriver from the [IBM Hosted URL](#downloadCli) and can set the **IBM_DB_INSTALLER_URL** environment variable to the downloaded "tar/zipped clidriver's" parent directory path. No need to untar/unzip the clidriver and do not change the name of downloaded file.
-
+- TIP:
+	- If you don't have alternate hosting URL then, you can download the tar/zipped file of clidriver from the [IBM Hosted URL](#downloadCli) and can set the **IBM_DB_INSTALLER_URL** environment variable to the downloaded "tar/zipped clidriver's" parent directory path. No need to untar/unzip the clidriver and do not change the name of downloaded file.
 
 ### <a name="downloadCli"></a> Download clidriver ([based on your platform & architecture](#systemDetails)) from the below IBM Hosted URL:
 > [DOWNLOAD CLI DRIVER](https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/)
@@ -63,7 +72,50 @@ npm install ibm_db
 |              |  others        |linuxia32_odbc_cli.tar.gz|  Yes         |
 |Windows       |  x64           |ntx64_odbc_cli.zip       |  Yes         |
 |              |  x32           |nt32_odbc_cli.zip        |  Not supported with node-ibm_db          |
+|z/OS          |  s390x         |ODBC support from IBM Db2 for z/OS 11.0 or 12.0 | Yes  |
 
+
+### Configure ODBC driver on z/OS
+
+Please refer to the [ODBC Guide and References](https://www.ibm.com/support/knowledgecenter/SSEPEK/pdf/db2z_12_odbcbook.pdf) cookbook for how to configure your ODBC driver.   Specifically, you need to ensure you have:
+
+1. Binded the ODBC packages.  A sample JCL is provided in the `SDSNSAMP` dataset in member `DSNTIJCL`.  Customize the JCL with specifics to your system.
+
+2. Update the `STEPLIB` environment variable to include the Db2 SDSNEXIT, SDSNLOAD and SDSNLOD2 data sets. You can set the `STEPLIB `environment variable in your `.profile` with the following statement, after defining `IBM_DB_HOME` to the high level qualifier of your Db2 datasets as instructed above:
+
+    ```sh
+    # Assumes IBM_DB_HOME specifies the HLQ of the Db2 datasets.
+    export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME:SDSNL0D2  
+    ```
+
+3. Configured an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:
+
+    ```
+    MULTICONTEXT=1
+    CURRENTAPPENSCH=ASCII
+    ```
+
+    Here is a sample of a complete initialization file:
+
+    ```
+    ; This is a comment line...
+    ; Example COMMON stanza
+    [COMMON]
+    MVSDEFAULTSSID=VC1A
+    CONNECTTYPE=1
+    MULTICONTEXT=1
+    CURRENTAPPENSCH=ASCII
+    ; Example SUBSYSTEM stanza for VC1A subsystem
+    [VC1A]
+    MVSATTACHTYPE=RRSAF
+    PLANNAME=DSNACLI
+    ; Example DATA SOURCE stanza for STLEC1 data source
+    [STLEC1]
+    AUTOCOMMIT=1
+    CURSORHOLD=1
+    ```
+
+    Reference Chapter 3 in the [ODBC Guide and References](https://www.ibm.com/support/knowledgecenter/SSEPEK/pdf/db2z_12_odbcbook.pdf) for more instructions.
 
 
 ## Quick Example
@@ -194,7 +246,14 @@ var Database = require("ibm_db").Database
 
 Open a connection to a database.
 
-* **connectionString** - The connection string for your database
+* **connectionString** - The connection string for your database.
+    * For distributed platforms, the connection string is typically defined as:
+    `DATABASE=dbname;HOSTNAME=hostname;PORT=port;PROTOCOL=TCPIP;UID=username;PWD=passwd`
+    * For z/OS, the ODBC driver makes both local and remote connections using DSN, UID and PWD.
+    The connection string is typically defined as: `DSN=dbname;UID=username;PWD=passwd`.  To
+    connect to remote Db2 databases, the connectivity information will need to be set up in the
+    Communications Database (CDB).  Please refer to scenario 1 in the following
+    [article](https://www.ibm.com/developerworks/data/library/techarticle/0310chong/0310chong.html).
 * **options** - _OPTIONAL_ - Object type. Can be used to avoid multiple 
     loading of native ODBC library for each call of `.open`. Also, can be used
     to pass connectTimeout value and systemNaming(true/false) for i5/OS server.
@@ -907,9 +966,11 @@ flag `DEBUG` to the defines section of the `binding.gyp` file and then execute
 
 ### Unicode
 
-By default, UNICODE suppport is enabled. This should provide the most accurate
-way to get Unicode strings submitted to your database. For best results, you 
-may want to put your Unicode string into bound parameters. 
+By default on distributed platforms, UNICODE suppport is enabled. This should
+provide the most accurate way to get Unicode strings submitted to your database.
+For best results, you may want to put your Unicode string into bound parameters.
+
+On z/OS, UNICODE is disabled by default.
 
 However, if you experience issues or you think that submitting UTF8 strings will
 work better or faster, you can remove the `UNICODE` define in `binding.gyp`

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,8 +11,10 @@
       'include_dirs': [
         "<!(node -e \"require('nan')\")"
       ],
-      'defines' : [
-        'UNICODE',
+      'conditions' : [
+        [ 'OS != "zos"',
+          { 'defines' : [ 'UNICODE'], }
+        ]
       ],
       "variables": {
         # Set the linker location, no extra linking needed, just link backwards one directory
@@ -40,7 +42,11 @@
             'include_dirs': ['$(IBM_DB_HOME)/include'],
             'cflags' : ['-g'],
           }],
-
+        [ 'OS == "zos" ',
+          { 'libraries' : ['dsnao64c.x'],
+            'include_dirs': ['build/include'],
+            'cflags' : ['-g']
+          }],
         [ 'OS == "mac" and target_arch =="x64" ',
           { 'xcode_settings': {'GCC_ENABLE_CPP_EXCEPTIONS': 'YES' },
             'libraries' : ['-L$(IBM_DB_HOME)/lib ', '-ldb2'],

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -81,58 +81,89 @@ var install_node_ibm_db = function(file_url) {
             IS_ENVIRONMENT_VAR = false;
         }
 
-        IBM_DB_INCLUDE = path.resolve(IBM_DB_HOME, 'include');
-        if (fs.existsSync(IBM_DB_HOME + "/lib64")) {
-           IBM_DB_LIB = path.resolve(IBM_DB_HOME, 'lib64');
-        } else if (fs.existsSync(IBM_DB_HOME + "/lib32")) {
-           IBM_DB_LIB = path.resolve(IBM_DB_HOME, 'lib32');
+        if (platform == 'os390') {
+          // On z/OS, we need to extract the include header files from
+          // SDSNC.H, and the sidedeck definition from SDSNMACS(DSNAO64C)
+          var buildDir = CURRENT_DIR + '/build';
+          if (!fs.existsSync(buildDir)) {
+             fs.mkdirSync(buildDir, 0744);
+          }
+          var includeDir = buildDir + '/include';
+          if (!fs.existsSync(includeDir)) {
+             fs.mkdirSync(includeDir, 0744);
+          }
+          // Copy the header files from SDSNC.H
+          execSync("cp \"//'" + IBM_DB_HOME + ".SDSNC.H'\" " + includeDir);
+
+          // Add .h suffix to header files.
+          var headers = fs.readdirSync(includeDir);
+          for (var i in headers) {
+            var pattern = /\.h$/i;
+            var headerFile = includeDir + "/" + headers[i];
+            if (!headerFile.match(pattern)) {
+               fs.renameSync(headerFile, headerFile + ".h");
+            }
+          }
+
+          // Copy the sidedeck definition to USS
+          // Need to use TSO OPUT command to retain the FB80.
+          execSync("tso \"oput '" + IBM_DB_HOME + ".SDSNMACS(DSNAO64C)' '" + buildDir + "/dsnao64c.x'\" | cat");
+          // Build the binary
+          buildBinary(!IS_ENVIRONMENT_VAR);
         } else {
-           IBM_DB_LIB = path.resolve(IBM_DB_HOME, 'lib');
-        }
+                IBM_DB_INCLUDE = path.resolve(IBM_DB_HOME, 'include');
+                if (fs.existsSync(IBM_DB_HOME + "/lib64")) {
+                        IBM_DB_LIB = path.resolve(IBM_DB_HOME, 'lib64');
+                } else if (fs.existsSync(IBM_DB_HOME + "/lib32")) {
+                        IBM_DB_LIB = path.resolve(IBM_DB_HOME, 'lib32');
+                } else {
+                        IBM_DB_LIB = path.resolve(IBM_DB_HOME, 'lib');
+                }
 
-        if(IS_ENVIRONMENT_VAR){
-            console.log('IBM_DB_HOME environment variable have already been ' +
-            'set to -> ' + IBM_DB_HOME +
-            '\n\nDownloading of clidriver skipped - build is in progress...\n');
-        }else{
-            console.log('Rebuild Process: Found clidriver at -> '+ IBM_DB_HOME +
-            '\n\nDownloading of clidriver skipped - build is in progress...\n');
-        }
+                if(IS_ENVIRONMENT_VAR){
+                        console.log('IBM_DB_HOME environment variable have already been ' +
+                                        'set to -> ' + IBM_DB_HOME +
+                                        '\n\nDownloading of clidriver skipped - build is in progress...\n');
+                }else{
+                        console.log('Rebuild Process: Found clidriver at -> '+ IBM_DB_HOME +
+                                        '\n\nDownloading of clidriver skipped - build is in progress...\n');
+                }
 
-        if (!fs.existsSync(IBM_DB_HOME)) {
-            console.log(IBM_DB_HOME + ' directory does not exist. Please check if you have ' + 
-                        'set the IBM_DB_HOME environment variable\'s value correctly.\n');
-        }
+                if (!fs.existsSync(IBM_DB_HOME)) {
+                        console.log(IBM_DB_HOME + ' directory does not exist. Please check if you have ' + 
+                                        'set the IBM_DB_HOME environment variable\'s value correctly.\n');
+                }
 
-        if(!(platform == 'win32' && IS_ENVIRONMENT_VAR == false)){
-            if (!fs.existsSync(IBM_DB_INCLUDE)) {
-                console.log(IBM_DB_INCLUDE + ' directory does not exist. Please check if you have ' + 
-                        'set the IBM_DB_HOME environment variable\'s value correctly.\n');
-            }
-        }
+                if(!(platform == 'win32' && IS_ENVIRONMENT_VAR == false)){
+                        if (!fs.existsSync(IBM_DB_INCLUDE)) {
+                                console.log(IBM_DB_INCLUDE + ' directory does not exist. Please check if you have ' + 
+                                                'set the IBM_DB_HOME environment variable\'s value correctly.\n');
+                        }
+                }
 
-        if (!fs.existsSync(IBM_DB_LIB)) {
-            console.log(IBM_DB_LIB + ' directory does not exist. Please check if you have ' + 
-                        'set the IBM_DB_HOME environment variable\'s value correctly.\n');
-        }
-        if( platform != 'win32') {
-            if(!fs.existsSync(IBM_DB_HOME + "/lib"))
-                fs.symlinkSync(IBM_DB_LIB, path.resolve(IBM_DB_HOME, 'lib'));
+                if (!fs.existsSync(IBM_DB_LIB)) {
+                        console.log(IBM_DB_LIB + ' directory does not exist. Please check if you have ' + 
+                                        'set the IBM_DB_HOME environment variable\'s value correctly.\n');
+                }
+                if( platform != 'win32') {
+                        if(!fs.existsSync(IBM_DB_HOME + "/lib"))
+                                fs.symlinkSync(IBM_DB_LIB, path.resolve(IBM_DB_HOME, 'lib'));
 
-            if((platform == 'linux') || (platform =='aix') || 
-               (platform == 'darwin' && arch == 'x64')) {
-                removeWinBuildArchive();
-                buildBinary(!IS_ENVIRONMENT_VAR);
-            }
-        }
-        else if(platform == 'win32' && arch == 'x64') {
-            buildBinary(!IS_ENVIRONMENT_VAR);
-        }
-        else {
-            console.log('Building binaries for node-ibm_db. This platform ' +
-            'is not completely supported, you might encounter errors. ' +
-            'In such cases please open an issue on our repository, ' +
-            'https://github.com/ibmdb/node-ibm_db. \n');
+                        if((platform == 'linux') || (platform =='aix') ||
+                                        (platform == 'darwin' && arch == 'x64')) {
+                                removeWinBuildArchive();
+                                buildBinary(!IS_ENVIRONMENT_VAR);
+                        }
+                }
+                else if(platform == 'win32' && arch == 'x64') {
+                        buildBinary(!IS_ENVIRONMENT_VAR);
+                }
+                else {
+                        console.log('Building binaries for node-ibm_db. This platform ' +
+                                        'is not completely supported, you might encounter errors. ' +
+                                        'In such cases please open an issue on our repository, ' +
+                                        'https://github.com/ibmdb/node-ibm_db. \n');
+                }
         }
     }
     else
@@ -141,7 +172,7 @@ var install_node_ibm_db = function(file_url) {
             if(arch == 'x64') {
                 installerfileURL = installerURL + 'ntx64_odbc_cli.zip';
             }
-        } 
+        }
         else if(platform == 'linux') 
         {
             if(arch == 'x64') {
@@ -182,7 +213,17 @@ var install_node_ibm_db = function(file_url) {
                 installerfileURL = installerURL + 'aix64_odbc_cli.tar.gz';
             }
         }
-        else 
+        else if(platform == 'os390')
+        {
+            // zOS ODBC driver is part of Db2 installation.  Users need to
+            // specify IBM_DB_HOME environment variable to the Db2 datasets
+            // to allow the installer to access the necessary header files and
+            // sidedeck definitions to build the node binding.
+            console.log('Please set environment variable IBM_DB_HOME to the HLQ' +
+                        'of your DB2 libraries.\n');
+            process.exit(1);
+        }
+        else
         {
             installerfileURL = installerURL + platform + arch + 
                                '_odbc_cli.tar.gz';

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -922,7 +922,7 @@ Database.prototype.describe = function(obj, callback)
 
   //set some defaults if they weren't passed
   obj.schema = obj.schema || "%";
-  obj.type = obj.type || "table";
+  obj.type = obj.type || "TABLE";
 
   if (obj.table && obj.column)
   {
@@ -937,7 +937,7 @@ Database.prototype.describe = function(obj, callback)
   else
   {
     //get the tables in the database
-    self.tables(obj.database, obj.schema, null, obj.type || "table", callback);
+    self.tables(obj.database, obj.schema, null, obj.type, callback);
   }
 }; //Database.describe
 

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -38,6 +38,11 @@ using namespace node;
 #define FETCH_OBJECT 4
 #define SQL_DESTROY 9999
 
+// Workaround(zOS): Db2 supplied headers do not define SQL_SUCCEEDED
+#ifndef SQL_SUCCEEDED
+#define SQL_SUCCEEDED(rc) (((rc)&(~1))==0)
+#endif
+
 // Free Bind Parameters 
 #define FREE_PARAMS( params, count )                                 \
     Parameter prm;                                                   \

--- a/test/common.js
+++ b/test/common.js
@@ -1,42 +1,64 @@
 var odbc = require("../");
+const os = require('os');
 
 //exports.connectionString = "DRIVER={DB2 ODBC Driver};DATABASE=SAMPLE;UID=db2admin;PWD=db2admin;HOSTNAME=localhost;port=50000;PROTOCOL=TCPIP";
 exports.connectionString = "";
 
 try {
-  exports.connectionObject = require('./config.testConnectionStrings.json');
+  if (os.type() === "OS/390") {
+    exports.connectionObject = require('./config.testConnectionStrings.zos.json');
+  } else {
+    exports.connectionObject = require('./config.testConnectionStrings.json');
+  }
 }
 catch (e) {
-  exports.connectionObject = {
-    DRIVER : "{DB2 ODBC Driver}",
-    DATABASE : "SAMPLE",
-    HOSTNAME : "localhost",
-    UID : "db2admin",
-    PWD : "db2admin",
-    PORT : "50000",
-    PROTOCOL : "TCPIP"
-  };
+  if (os.type() === "OS/390") {
+    // On z/OS, ODBC driver uses a local connection that only requires DSN, UID and PWD.
+    exports.connectionObject = {
+       DSN : "{Db2 ODBC Driver}",
+       UID : "db2admin",
+       PWD : "db2admin"
+    };
+  } else {
+    exports.connectionObject = {
+      DRIVER : "{DB2 ODBC Driver}",
+      DATABASE : "SAMPLE",
+      HOSTNAME : "localhost",
+      UID : "db2admin",
+      PWD : "db2admin",
+      PORT : "50000",
+      PROTOCOL : "TCPIP"
+    };
+  }
 }
 
-exports.connectionObject.DATABASE = process.env.IBM_DB_DBNAME  || exports.connectionObject.DATABASE;
-exports.connectionObject.HOSTNAME = process.env.IBM_DB_HOSTNAME || exports.connectionObject.HOSTNAME;
-exports.connectionObject.UID     = process.env.IBM_DB_UID      || exports.connectionObject.UID;
-exports.connectionObject.PWD     = process.env.IBM_DB_PWD      || exports.connectionObject.PWD;
-exports.connectionObject.PORT    = process.env.IBM_DB_PORT     || exports.connectionObject.PORT;
-exports.connectionObject.PROTOCOL = process.env.IBM_DB_PROTOCOL || exports.connectionObject.PROTOCOL;
 
 //checks if schema is defined
 if (process.env.IBM_DB_SCHEMA !== 'undefined') {
     exports.connectionObject.CURRENTSCHEMA = process.env.IBM_DB_SCHEMA || exports.connectionObject.CURRENTSCHEMA;
 }
 
-for(key in exports.connectionObject) 
-{
+exports.connectionObject.UID     = process.env.IBM_DB_UID      || exports.connectionObject.UID;
+exports.connectionObject.PWD     = process.env.IBM_DB_PWD      || exports.connectionObject.PWD;
+
+// Construct the connection string
+if (os.type() === "OS/390") {
+  // On z/OS, ODBC driver uses a local connection that only requires DSN, UID and PWD.
+  exports.connectionObject.DSN = process.env.IBM_DB_DBNAME  || exports.connectionObject.DSN;
+  exports.connectionString = "DSN=" + exports.connectionObject["DSN"] + ";" +
+                             "UID=" + exports.connectionObject["UID"] + ";" +
+                             "PWD=" + exports.connectionObject["PWD"] + ";";
+} else {
+  exports.connectionObject.DATABASE = process.env.IBM_DB_DBNAME  || exports.connectionObject.DATABASE;
+  exports.connectionObject.HOSTNAME = process.env.IBM_DB_HOSTNAME || exports.connectionObject.HOSTNAME;
+  exports.connectionObject.PORT    = process.env.IBM_DB_PORT     || exports.connectionObject.PORT;
+  exports.connectionObject.PROTOCOL = process.env.IBM_DB_PROTOCOL || exports.connectionObject.PROTOCOL;
+  for(key in exports.connectionObject) {
     if(exports.connectionObject[key] != undefined)
       exports.connectionString = exports.connectionString + key + "=" +
                                  exports.connectionObject[key] + ";" ;
+  }
 }
-
 //if (process.argv.length === 3) {
 //  exports.connectionString = process.argv[2];
 //}

--- a/test/config.testConnectionStrings.zos.json
+++ b/test/config.testConnectionStrings.zos.json
@@ -1,0 +1,4 @@
+{ "DSN" : "SAMPLE",
+  "UID" : "newton",
+  "PWD" : "db2admin",
+}

--- a/test/test-all-data-types.js
+++ b/test/test-all-data-types.js
@@ -10,7 +10,7 @@ var common = require("./common")
       try {
         conn.querySync("drop table mytab1");
       } catch (e) {}
-      conn.querySync("create table mytab1 (c1 int, c2 SMALLINT, c3 BIGINT, c4 INTEGER, c5 DECIMAL(3), c6 NUM, c7 float, c8 double, c9 decfloat, c10 char(10), c11 varchar(10), c12 char for bit data, c13 clob(10), c14 date, c15 time, c16 timestamp, c17 blob(10))");
+      conn.querySync("create table mytab1 (c1 int, c2 SMALLINT, c3 BIGINT, c4 INTEGER, c5 DECIMAL(3), c6 NUMERIC, c7 float, c8 double, c9 decfloat, c10 char(10), c11 varchar(10), c12 char for bit data, c13 clob(10), c14 date, c15 time, c16 timestamp, c17 blob(10)) ccsid unicode");
       conn.querySync("insert into mytab1 values (1, 2, 456736789, 1234, 67.98, 5689, 56.2390, 34567890, 45.234, 'bimal', 'kumar', '\x50', 'jha123456', '2015-09-10', '10:16:33', '2015-09-10 10:16:33.770139', BLOB(x'616263'))");
       conn.query("select * from mytab1", function(err, data) {
           if(err) console.log(err);

--- a/test/test-bad-connection-string.js
+++ b/test/test-bad-connection-string.js
@@ -4,6 +4,8 @@ var common = require("./common")
   , assert = require("assert")
   ;
 
+const os = require("os");
+
 assert.throws(function () {
   db.openSync("this is wrong");
 });
@@ -13,10 +15,16 @@ assert.equal(db.connected, false);
 db.open("this is wrong", function(err) {
   console.log(err);
   
-  if( /^win/.test(process.platform) )
+  if( /^win/.test(process.platform) ) {
     assert.deepEqual(err.message, '[IBM][CLI Driver] SQL1024N  A database connection does not exist.  SQLSTATE=08003\r\n');
-  else
+  } else if (os.type() === "OS/390") {
+    // Expected error message on z/OS is SQLCODE = -950 SQLSTATE = 42705
+    // ERROR:  THE LOCATION NAME SPECIFIED IN THE CONNECT STATEMENT IS INVALID OR NOT LISTED IN THE COMMUNICATIONS DATABASE
+    assert(/SQLCODE\s*=\s*-950/.test(err.message));
+    assert.equal(err.state, 42705);
+  } else {
     assert.deepEqual(err.message, '[IBM][CLI Driver] SQL1024N  A database connection does not exist.  SQLSTATE=08003\n');
+  }
   
   assert.equal(db.connected, false);
 });

--- a/test/test-blob-file.js
+++ b/test/test-blob-file.js
@@ -22,8 +22,8 @@ ibmdb.open(cn, function (err,conn)
     conn.querySync("create table mytab (empId int, photo BLOB(1M), trace CLOB(1M))");
     } catch (e) {};
   
-  var img1= 'data/phool.jpg'; //fs.readFileSync('phool.jpg','binary');
-  var text= 'data/trc.fmt'; //fs.readFileSync('trc.fmt','ascii');
+  var img1= __dirname + '/data/phool.jpg'; //fs.readFileSync('phool.jpg','binary');
+  var text= __dirname + '/data/trc.fmt'; //fs.readFileSync('trc.fmt','ascii');
 
   var len1  = fs.statSync(img1)["size"];
   var len2  = fs.statSync(text)["size"];

--- a/test/test-blocking-issue210.js
+++ b/test/test-blocking-issue210.js
@@ -18,8 +18,23 @@ pool.open(connectionString, function( err, conn) {
           conn.querySync("drop table mtab2"); } catch(e) {};
     conn.querySync("create table mtab1(c1 varchar(30), c2 varchar(20))");
     conn.querySync("create table mtab2(c1 varchar(30), c2 varchar(20))");
-    conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
-    conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // Db2 on z/OS does not support multi-row inserts
+      conn.querySync("Insert into mtab1 values ('1', 'bimal')");
+      conn.querySync("Insert into mtab1 values ('2', 'kumar')");
+      conn.querySync("Insert into mtab1 values ('3', 'jha')");
+      conn.querySync("Insert into mtab1 values ('4', 'kamal')");
+      conn.querySync("Insert into mtab1 values ('5', 'ibm')");
+
+      conn.querySync("Insert into mtab1 values ('1', 'bimal')");
+      conn.querySync("Insert into mtab1 values ('2', 'kumar')");
+      conn.querySync("Insert into mtab1 values ('3', 'jha')");
+      conn.querySync("Insert into mtab1 values ('4', 'kamal')");
+      conn.querySync("Insert into mtab1 values ('5', 'ibm')");
+    } else {
+      conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
+      conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
+    }
     for(var i = 0; i < 6 ; i++) {
       conn.querySync("insert into mtab2 (select * from mtab1)");
       conn.querySync("insert into mtab1 (select * from mtab2)");
@@ -69,8 +84,16 @@ pool.open(connectionString, function (err, connection) {
 
 // Test case for issue #230 - ? takes long time. Found a server issue.
 var testLongTime = function(conn) {
-    conn.querySync("insert into mtab1 values ('330107196906080910', '330107196906080910'), "+
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // Db2 on z/OS does not support multi-row inserts
+      conn.querySync("insert into mtab1 values ('330107196906080910', '330107196906080910')");
+      conn.querySync("insert into mtab1 values ('330107196906080910', '330107196906080910')");
+      conn.querySync("insert into mtab1 values ('330107196906080910', '')");
+    } else {
+      conn.querySync("insert into mtab1 values ('330107196906080910', '330107196906080910'), "+
                    "('330107196906080910', '330107196906080910'), ('330107196906080910', '')");
+
+    }
     var query1 = "select c1, c2 from mtab1 where (c1 in (?, ?) or c2 in (?, ?) and (? is null or c2 = ?))";
     var query2 = "select c1, c2 from mtab1 where (c1 in ('330107196906080910', '330107196906080910') " +
                  "or c2 in ('330107196906080910', '330107196906080910') and ('' is null or c2 = ''))";

--- a/test/test-call-stmt.js
+++ b/test/test-call-stmt.js
@@ -7,18 +7,34 @@ var common = require("./common")
   , schema = common.connectionObject.CURRENTSCHEMA;
 
 if(schema == undefined) schema = "NEWTON";
-var query = "CaLL " + schema + ".proc1(?, ?, ?)";
+var query = "CaLL " + schema + ".PROC1(?, ?, ?)";
 ibmdb.open(cn, function (err, conn)
 {
     if(err) console.log(err);
     assert.equal(err, null);
     try {
-          conn.querySync("drop procedure " + schema + ".proc1(INT, INT, VARCHAR(20))");
+      if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+        // The DROP PROCEDURE syntax on z/OS can only specify the name of the procedure to drop.
+        conn.querySync("drop procedure " + schema + ".PROC1");
+      } else {
+        conn.querySync("drop procedure " + schema + ".PROC1(INT, INT, VARCHAR(20))");
+      }
     } catch(e) {}
 
-    conn.querySync("create or replace procedure " + schema + ".proc1 " +
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // CREATE OR REPLACE syntax is not supported on z/OS.
+      // When creating an SQL native procedure on z/OS, you will need to have a WLM environment
+      // defined for your system if you want to run the procedure in debugging mode.
+      // Adding "disable debug mode" to bypass this requirement.
+      conn.querySync("create procedure " + schema + ".PROC1 " +
+                   "(IN v1 INTEGER, OUT v2 INTEGER, INOUT v3 VARCHAR(20)) " +
+                   "disable debug mode " +
+                   "BEGIN set v2 = v1 + 1; set v3 = 'verygood'; END");
+    } else {
+      conn.querySync("create or replace procedure " + schema + ".PROC1 " +
                    "(IN v1 INTEGER, OUT v2 INTEGER, INOUT v3 VARCHAR(20)) " +
                    "BEGIN set v2 = v1 + 1; set v3 = 'verygood'; END");
+    }
     var param1 = {ParamType:"INPUT", DataType:1, Data:0};
     var param2 = {ParamType:"OUTPUT", DataType:1, Data:0};
     var param3 = {ParamType:"INOUT", DataType:1, Data:"abc", Length:30};
@@ -27,11 +43,32 @@ ibmdb.open(cn, function (err, conn)
     assert.deepEqual(result, [ 1, 'verygood' ]);
     console.log("Output Parameters V2 = ", result[0], ", V3 = ", result[1]);
 
-    conn.querySync("drop procedure " + schema + ".proc1(INT, INT, VARCHAR(20))");
-    conn.querySync("create or replace procedure " + schema + ".proc2 (IN v1 INTEGER) BEGIN END");
-    result = conn.querySync("call " + schema + ".proc2(?)", [param1]);
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // The DROP PROCEDURE syntax on z/OS can only specify the name of the procedure to drop.
+      conn.querySync("drop procedure " + schema + ".PROC1");
+    } else {
+      conn.querySync("drop procedure " + schema + ".PROC1(INT, INT, VARCHAR(20))");
+    }
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // CREATE OR REPLACE syntax is not supported on z/OS.  Drop PROCEDURE first.
+      // When creating an SQL native procedure on z/OS, you will need to have a WLM environment
+      // defined for your system if you want to run the procedure in debugging mode.
+      // Adding "disable debug mode" to bypass this requirement.
+      try {
+        conn.querySync("drop procedure " + schema + ".PROC2");
+      } catch (e) { }
+      conn.querySync("create procedure " + schema + ".PROC2 (IN v1 INTEGER) disable debug mode BEGIN END");
+    } else {
+      conn.querySync("create or replace procedure " + schema + ".PROC2 (IN v1 INTEGER) BEGIN END");
+    }
+    result = conn.querySync("call " + schema + ".PROC2(?)", [param1]);
     assert.deepEqual(result, []);
-    conn.querySync("drop procedure " + schema + ".proc2(INT)");
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // The DROP PROCEDURE syntax on z/OS can only specify the name of the procedure to drop.
+      conn.querySync("drop procedure " + schema + ".PROC2");
+    } else {
+      conn.querySync("drop procedure " + schema + ".PROC2(INT)");
+    }
     conn.closeSync();
     console.log('done');
 });

--- a/test/test-issue253.js
+++ b/test/test-issue253.js
@@ -3,6 +3,8 @@ var ibmdb = require("../")
     , assert = require("assert")
     , cn = common.connectionString;
 
+const os = require("os");
+
 var createSQL =  "create table issue253 (name int)";
 var selectSQL =  "select * from issue253 WHERE CURRENT DATE = '2017-04-17 0'";
 var dropSQL   =  "drop table issue253";
@@ -19,7 +21,18 @@ ibmdb.open(cn, function (err,conn) {
       var errorFound = false;
      
       if (err.message) {
-        var errorFound = err.message.includes("SQL0180N");
+        if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+          // zOS Db2 returns SQLCode -181 and SQLState 22007 for
+          // THE STRING REPRESENTATION OF A DATETIME VALUE IS NOT
+          // A VALID DATETIME VALUE
+          if (os.type() === "OS/390") {
+            var errorFound = err.message.includes("SQLCODE = -181");
+          } else {
+            var errorFound = err.message.includes("SQL0181N");
+          }
+        } else {
+          var errorFound = err.message.includes("SQL0180N");
+        }
       }
       assert.equal(errorFound, true);
   });

--- a/test/test-max-pool-size.js
+++ b/test/test-max-pool-size.js
@@ -19,8 +19,23 @@ pool.open(connectionString, function( err, conn) {
           conn.querySync("drop table mtab2"); } catch(e) {};
     conn.querySync("create table mtab1(c1 varchar(30), c2 varchar(20))");
     conn.querySync("create table mtab2(c1 varchar(30), c2 varchar(20))");
-    conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
-    conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // Db2 on z/OS does not support multi-row inserts
+      conn.querySync("Insert into mtab1 values ('1', 'bimal')");
+      conn.querySync("Insert into mtab1 values ('2', 'kumar')");
+      conn.querySync("Insert into mtab1 values ('3', 'jha')");
+      conn.querySync("Insert into mtab1 values ('4', 'kamal')");
+      conn.querySync("Insert into mtab1 values ('5', 'ibm')");
+
+      conn.querySync("Insert into mtab1 values ('1', 'bimal')");
+      conn.querySync("Insert into mtab1 values ('2', 'kumar')");
+      conn.querySync("Insert into mtab1 values ('3', 'jha')");
+      conn.querySync("Insert into mtab1 values ('4', 'kamal')");
+      conn.querySync("Insert into mtab1 values ('5', 'ibm')");
+    } else {
+      conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
+      conn.querySync("Insert into mtab1 values ('1', 'bimal'),('2','kumar'),('3', 'jha'), ('4', 'kamal'), ('5', 'ibm')");
+    }
     for(var i = 0; i < 3 ; i++) {  // 4 is 340 rows and 6 is 2330 rows
       conn.querySync("insert into mtab2 (select * from mtab1)");
       conn.querySync("insert into mtab1 (select * from mtab2)");

--- a/test/test-prepareSync-bad-sql.js
+++ b/test/test-prepareSync-bad-sql.js
@@ -4,10 +4,20 @@ var common = require("./common")
   , assert = require("assert")
   ;
 
+const os = require("os");
+
 db.openSync(common.connectionString);
 assert.equal(db.connected, true);
 
-var stmt = db.prepareSync("asdf asdf asdf asdf sadf ");
+try {
+  var stmt = db.prepareSync("asdf asdf asdf asdf sadf ");
+} catch (e) {
+  // ODBC driver on z/OS does not have deferred prepare enabled
+  // by default. As a result, we expect the error to be thrown
+  // on the prepare.
+  assert.deepEqual(os.type(), "OS/390", "With deferred prepare in Db2Connect on distributed platforms, bad sql should not throw error.");
+  process.exit(0);
+}
 assert.equal(stmt.constructor.name, "ODBCStatement");
   
 stmt.bindSync(["hello world", 1, null]);

--- a/test/test-queryStream.js
+++ b/test/test-queryStream.js
@@ -4,6 +4,8 @@ var common = require("./common")
   , assert = require("assert")
   ;
 
+const os = require("os");
+
 db.openSync(common.connectionString);
 assert.equal(db.connected, true);
 
@@ -12,7 +14,7 @@ var stream = db.queryStream("wrong query");
 stream.once('data', function (data) {
   throw new Error("data should not return from an erroring queryStream.");
 }).once('error', function (err) {
-  assert.equal(err.state, '42601');
+  assert.equal(err.state, (os.type() === "OS/390")?'37000':'42601');
   db.close(function(){
       console.log("Error test for queryStream completed successfully.");
   });

--- a/test/test-querySync-select.js
+++ b/test/test-querySync-select.js
@@ -12,12 +12,15 @@ assert.deepEqual(data, [{ COLINT: 1, COLTEXT: 'some test' }]);
 
 // Test multiple result set returned by querySync.
 db.fetchMode = 3; // Fetch in array mode.
-data = db.querySync("select 1, 2, 3 from sysibm.sysdummy1; select 4, 5, 6 from sysibm.sysdummy1;");
+data[0] = db.querySync("select 1, 2, 3 from sysibm.sysdummy1");
+data[1] = db.querySync("select 4, 5, 6 from sysibm.sysdummy1");
 console.log(data);
 assert.deepEqual(data, [ [ [ 1, 2, 3 ] ], [ [ 4, 5, 6 ] ] ]);
 
 db.fetchMode = 4; // Fetch in object mode. It is default mode too.
-data = db.querySync("select 1 from sysibm.sysdummy1;select 2 from sysibm.sysdummy1;select 3 from sysibm.sysdummy1");
+data[0] = db.querySync("select 1 from sysibm.sysdummy1");
+data[1] = db.querySync("select 2 from sysibm.sysdummy1");
+data[2] = db.querySync("select 3 from sysibm.sysdummy1");
 console.log(data);
 assert.deepEqual(data[2], [ { '1': 3 } ]);
 db.closeSync();

--- a/test/test-sp-resultset-execute.js
+++ b/test/test-sp-resultset-execute.js
@@ -9,11 +9,29 @@ var common = require("./common")
 
 if(schema == undefined) schema = "NEWTON";
    
-var proc1 = "create or replace procedure " + schema + ".proc2 ( IN v1 int, INOUT v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; set v2 = 'success'; end";
-var proc2 = "create or replace procedure " + schema + ".proc2 ( IN v1 int, INOUT v2 varchar(30) )  language sql begin  set v2 = 'success'; end";
-var proc3 = "create or replace procedure " + schema + ".proc2 ( IN v1 int, IN v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; end";
-var query = "call " + schema + ".proc2(?, ?)";
+var proc1 = "create or replace procedure " + schema + ".PROC2 ( IN v1 int, INOUT v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; set v2 = 'success'; end";
+var proc2 = "create or replace procedure " + schema + ".PROC2 ( IN v1 int, INOUT v2 varchar(30) )  language sql begin  set v2 = 'success'; end";
+var proc3 = "create or replace procedure " + schema + ".PROC2 ( IN v1 int, IN v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; end";
+var query = "call " + schema + ".PROC2(?, ?)";
 var result;
+
+if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+  // Update the queries for Db2 on z/OS compatiability.
+  // - Does not support CREATE OR REPLACE syntax.
+ var dropProc = "drop procedure " + schema + ".PROC2";
+  proc1 = proc1.replace(" or replace", "");
+  proc2 = proc2.replace(" or replace", "");
+  proc3 = proc3.replace(" or replace", "");
+
+  // - When creating an SQL native procedure on z/OS, you will need to have a WLM environment
+  // defined for your system if you want to run the procedure in debugging mode. Adding
+  // "disable debug mode" to bypass this requirement.
+  proc1 = proc1.replace(" begin", " disable debug mode begin");
+  proc2 = proc2.replace(" begin", " disable debug mode begin");
+  proc3 = proc3.replace(" begin", " disable debug mode begin");
+}
+
+
 //ibmdb.debug(true);
 ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
     if(err) { 
@@ -24,10 +42,23 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
       conn.querySync("drop table " + schema + ".mytab1");
     } catch (e) {};
     conn.querySync({"sql":"create table " + schema + ".mytab1 (c1 int, c2 varchar(20))", "noResults":true});
-    conn.querySync("insert into " + schema + ".mytab1 values (2, 'bimal'), (3, 'kumar')");
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // Db2 on z/OS does not support multi-row inserts
+      conn.querySync("insert into " + schema + ".mytab1 values (2, 'bimal')");
+      conn.querySync("insert into " + schema + ".mytab1 values (3, 'kumar')");
+    } else {
+      conn.querySync("insert into " + schema + ".mytab1 values (2, 'bimal'), (3, 'kumar')");
+    }
+
     param2 = {ParamType:"INOUT", DataType:1, Data:"abc", Length:50};
 
     // Create SP with INOUT param and 2 Result Set.
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // CREATE OR REPLACE is not supported on z/OS.  Explicitly drop procedure.
+      try {
+         conn.querySync(dropProc);
+      } catch(e) { };
+    }
     conn.querySync(proc1);
     // Call SP Synchronously.
     stmt = conn.prepareSync(query);
@@ -71,6 +102,12 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
         stmt.closeSync();
 
         // Create SP with only OUT param and no resultset.
+        if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+          // CREATE OR REPLACE is not supported on z/OS.  Explicitly drop procedure.
+          try {
+            conn.querySync(dropProc);
+          } catch(e) { };
+        }
         conn.querySync(proc2);
         // Call SP Synchronously.
         stmt = conn.prepareSync(query);
@@ -101,6 +138,12 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
             stmt.closeSync();
 
             // Create SP with only Result Set and no OUT or INPUT param.
+            if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+              // CREATE OR REPLACE is not supported on z/OS.  Explicitly drop procedure.
+              try {
+                conn.querySync(dropProc);
+              } catch(e) { };
+            }
             conn.querySync(proc3);
             // Call SP Synchronously.
             stmt = conn.prepareSync(query);
@@ -141,7 +184,11 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
                 stmt.closeSync();
 
                 // Do Cleanup.
-                conn.querySync("drop procedure " + schema + ".proc2 ( INT, VARCHAR(30) )");
+		if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+                  conn.querySync("drop procedure " + schema + ".PROC2");
+		} else {
+                  conn.querySync("drop procedure " + schema + ".PROC2 ( INT, VARCHAR(30) )");
+                }
                 conn.querySync("drop table " + schema + ".mytab1");
                 // Close connection in last only.
                 conn.close(function (err) { console.log("done.");});

--- a/test/test-sp-resultset.js
+++ b/test/test-sp-resultset.js
@@ -5,10 +5,26 @@ var common = require("./common")
 
 if(schema == undefined) schema = "NEWTON";
 
-var proc1 = "create or replace procedure " + schema + ".proc2 ( IN v1 int, INOUT v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; set v2 = 'success'; end";
-var proc2 = "create or replace procedure " + schema + ".proc2 ( IN v1 int, INOUT v2 varchar(30) )  language sql begin  set v2 = 'success'; end";
-var proc3 = "create or replace procedure " + schema + ".proc2 ( IN v1 int, IN v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; end";
-var query = "call " + schema + ".proc2(?, ?)";
+var proc1 = "create or replace procedure " + schema + ".PROC2 ( IN v1 int, INOUT v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; set v2 = 'success'; end";
+var proc2 = "create or replace procedure " + schema + ".PROC2 ( IN v1 int, INOUT v2 varchar(30) )  language sql begin  set v2 = 'success'; end";
+var proc3 = "create or replace procedure " + schema + ".PROC2 ( IN v1 int, IN v2 varchar(30) )  dynamic result sets 2 language sql begin  declare cr1  cursor with return for select c1, c2 from " + schema + ".mytab1; declare cr2  cursor with return for select c2 from " + schema + ".mytab1; open cr1; open cr2; end";
+var query = "call " + schema + ".PROC2(?, ?)";
+
+if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+  // Update the queries for Db2 on z/OS compatiability.
+  // - Does not support CREATE OR REPLACE syntax.
+ var dropProc = "drop procedure " + schema + ".PROC2";
+  proc1 = proc1.replace(" or replace", "");
+  proc2 = proc2.replace(" or replace", "");
+  proc3 = proc3.replace(" or replace", "");
+
+  // - When creating an SQL native procedure on z/OS, you will need to have a WLM environment
+  // defined for your system if you want to run the procedure in debugging mode. Adding
+  // "disable debug mode" to bypass this requirement.
+  proc1 = proc1.replace(" begin", " disable debug mode begin");
+  proc2 = proc2.replace(" begin", " disable debug mode begin");
+  proc3 = proc3.replace(" begin", " disable debug mode begin");
+}
 var result;
 ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
     if(err) {
@@ -18,11 +34,25 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
     try {
       conn.querySync({"sql":"create table " + schema + ".mytab1 (c1 int, c2 varchar(20))", "noResults":true});
     } catch (e) {};
-    conn.querySync("insert into " + schema + ".mytab1 values (2, 'bimal'), (3, 'kumar')");
+
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // Db2 on z/OS does not support multi-row inserts
+      conn.querySync("insert into " + schema + ".mytab1 values (2, 'bimal')");
+      conn.querySync("insert into " + schema + ".mytab1 values (3, 'kumar')");
+    } else {
+      conn.querySync("insert into " + schema + ".mytab1 values (2, 'bimal'), (3, 'kumar')");
+    }
     param2 = {ParamType:"INOUT", DataType:1, Data:"abc", Length:50};
 
     // Create SP with INOUT param and 2 Result Set.
+    if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+      // CREATE OR REPLACE is not supported on z/OS.  Explicitly drop procedure.
+      try {
+         conn.querySync(dropProc);
+      } catch(e) { };
+    }
     conn.querySync(proc1);
+
     // Call SP Synchronously.
     result = conn.querySync(query, ['1', param2]);
     console.log("Result for Sync call of proc1 ==>");
@@ -38,6 +68,12 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
         }
 
         // Create SP with only OUT param and no resultset.
+        if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+          // CREATE OR REPLACE is not supported on z/OS.  Explicitly drop procedure.
+          try {
+            conn.querySync(dropProc);
+          } catch(e) { };
+        }
         conn.querySync(proc2);
         // Call SP Synchronously.
         result = conn.querySync(query, ['1', param2]);
@@ -54,6 +90,12 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
             }
 
             // Create SP with only Result Set and no OUT or INPUT param.
+            if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+              // CREATE OR REPLACE is not supported on z/OS.  Explicitly drop procedure.
+              try {
+                conn.querySync(dropProc);
+              } catch(e) { };
+            }
             conn.querySync(proc3);
             // Call SP Synchronously.
             result = conn.querySync(query, [1, 'abc']);
@@ -70,7 +112,11 @@ ibmdb.open(common.connectionString, {fetchMode : 3}, function (err, conn) {
                 }
 
                 // Do Cleanup.
-                conn.querySync("drop procedure " + schema + ".proc2 ( INT, VARCHAR(30) )");
+                if (process.env.IBM_DB_SERVER_TYPE === "ZOS") {
+                  conn.querySync("drop procedure " + schema + ".PROC2");
+                } else {
+                  conn.querySync("drop procedure " + schema + ".PROC2 ( INT, VARCHAR(30) )");
+                }
                 conn.querySync("drop table " + schema + ".mytab1");
                 // Close connection in last only.
                 conn.close(function (err) { console.log("done.");});

--- a/test/test-transaction-commit.js
+++ b/test/test-transaction-commit.js
@@ -8,70 +8,72 @@ var common = require("./common")
 
 db.openSync(common.connectionString);
 
-common.createTables(db, function (err, data) {
-  test1()
-  
-  function test1() {
-    db.beginTransaction(function (err) {
-      if (err) {
+common.dropTables(db, function (err) {
+  common.createTables(db, function (err, data) {
+    test1()
+
+    function test1() {
+      db.beginTransaction(function (err) {
+        if (err) {
         console.log("Error beginning transaction.");
         console.log(err);
         exitCode = 1
-      }
-      
-      var result = db.querySync("insert into " + common.tableName + " (COLINT, COLDATETIME, COLTEXT) VALUES (42, null, null)" );
+        }
 
-      //rollback
-      db.endTransaction(true, function (err) {
-        if (err) {
+        var result = db.querySync("insert into " + common.tableName + " (COLINT, COLDATETIME, COLTEXT) VALUES (42, null, null)" );
+
+        //rollback
+        db.endTransaction(true, function (err) {
+          if (err) {
           console.log("Error rolling back transaction");
           console.log(err);
           exitCode = 2
-        }
-        
-        data = db.querySync("select * from " + common.tableName);
-        
-        assert.deepEqual(data, []);
-        
-        test2();
+          }
+
+          data = db.querySync("select * from " + common.tableName);
+
+          assert.deepEqual(data, []);
+
+          test2();
+          });
       });
-    });
-  }
-  
-  function test2 () {
-    //Start a new transaction
-    db.beginTransaction(function (err) {
-      if (err) {
-        console.log("Error beginning transaction");
-        console.log(err);
-        exitCode = 3
-      }
-      
-      result = db.querySync("insert into " + common.tableName + " (COLINT, COLDATETIME, COLTEXT) VALUES (42, null, null)" );
-      
-      //commit
-      db.endTransaction(false, function (err) {
-        if (err) {
-          console.log("Error committing transaction");
+    }
+
+    function test2 () {
+      //Start a new transaction
+      db.beginTransaction(function (err) {
+          if (err) {
+          console.log("Error beginning transaction");
           console.log(err);
           exitCode = 3
-        }
-        
-        data = db.querySync("select * from " + common.tableName);
-        
-        assert.deepEqual(data, [ { COLINT: 42, COLDATETIME: null, COLTEXT: null } ]);
-        
-        finish();
+          }
+
+          result = db.querySync("insert into " + common.tableName + " (COLINT, COLDATETIME, COLTEXT) VALUES (42, null, null)" );
+
+          //commit
+          db.endTransaction(false, function (err) {
+            if (err) {
+            console.log("Error committing transaction");
+            console.log(err);
+            exitCode = 3
+            }
+
+            data = db.querySync("select * from " + common.tableName);
+
+            assert.deepEqual(data, [ { COLINT: 42, COLDATETIME: null, COLTEXT: null } ]);
+
+            finish();
+            });
       });
-    });
-  }
-  
-  function finish() {
-    common.dropTables(db, function (err) {
-      db.closeSync();
-      process.exit(exitCode);
-    });
-  }
+    }
+
+    function finish() {
+      common.dropTables(db, function (err) {
+          db.closeSync();
+          process.exit(exitCode);
+          });
+    }
+  });
 });
 
 


### PR DESCRIPTION
The following are changes to ibm_db for z/OS, leveraging the ODBC drivers available as part of Db2 for z/OS V11 and V12.  

Given that ODBC drivers are part of the local Db2 installation (there is no DB2Connect cli for z/OS), I've repurposed the IBM_DB_HOME env variable to require users specify the High Level Qualifier of the DB2 datasets on z/OS.  Updated the README/Installation and driverInstall scripts to reflect this change, and automatically pull the necessary header and sidedeck files to build the native add-on.

I've build down the changes to 4 separate commits to help with the review.
1.  README/INSTALL documentation updates.
2.  DriverInstall updates.
3.  Minor zOS specific changes to the ibm_db src.
4.  The testcase specific changes to support z/OS compatibility / differences with LUW.

The individual commit messages have a more detailed summary of the changes.  I've ran the included tests on Linux on Intel and on Z and have found no regressions.

DCO 1.1 Signed-off-by:  Joran Siu <joransiu@ca.ibm.com>