### PR TITLE
Add GRANT EXECUTE permissions step for z/OS ODBC

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -219,8 +219,8 @@ var install_node_ibm_db = function(file_url) {
             // specify IBM_DB_HOME environment variable to the Db2 datasets
             // to allow the installer to access the necessary header files and
             // sidedeck definitions to build the node binding.
-            console.log('Please set environment variable IBM_DB_HOME to the HLQ' +
-                        'of your DB2 libraries.\n');
+            console.log('Please set the environment variable IBM_DB_HOME to the ' + 
+                        'High Level Qualifier (HLQ) of your Db2 libraries.\n');
             process.exit(1);
         }
         else


### PR DESCRIPTION
Add instructions for granting the necessary EXECUTE privileges
for ODBC on z/OS to README.md.  Also, fix up minor error message
for IBM_DB_HOME environment variable on z/OS.

DCO 1.1 Signed-off-by: Joran Siu joransiu@ca.ibm.com