### PR TITLE
Accessor for column metadata

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -279,7 +279,7 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
     columns[i].index = i + 1;
     colname[0] = '\0';
     buflen = 0;
-    
+
     //get the column name
     ret = SQLColAttribute( hStmt,
                            columns[i].index,
@@ -292,9 +292,9 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
                            (SQLSMALLINT) MAX_FIELD_SIZE,
                            &buflen,
                            NULL);
-    
+
     //store the len attribute
-    columns[i].len = buflen;
+    columns[i].name_len = buflen;
     if(buflen> 0)
     {
         columns[i].name = new unsigned char[buflen+2];
@@ -303,7 +303,43 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
         columns[i].name[buflen+1] = '\0';
     }
     DEBUG_PRINTF("ODBC::GetColumns index = %i, buflen=%i\n", columns[i].index, buflen);
-    
+
+    //get max column length
+    ret = SQLColAttribute( hStmt,
+                           columns[i].index,
+                           SQL_DESC_DISPLAY_SIZE,
+                           NULL,
+                           0,
+                           NULL,
+                           &columns[i].max_display_len);
+
+    //get column precision
+    ret = SQLColAttribute( hStmt,
+                           columns[i].index,
+                           SQL_DESC_PRECISION,
+                           NULL,
+                           0,
+                           NULL,
+                           &columns[i].precision);
+
+    //get column scale
+    ret = SQLColAttribute( hStmt,
+                           columns[i].index,
+                           SQL_DESC_SCALE,
+                           NULL,
+                           0,
+                           NULL,
+                           &columns[i].scale);
+
+    //get column scale
+    ret = SQLColAttribute( hStmt,
+                           columns[i].index,
+                           SQL_DESC_LENGTH,
+                           NULL,
+                           0,
+                           NULL,
+                           &columns[i].field_len);
+
     //get the column type and store it directly in column[i].type
     ret = SQLColAttribute( hStmt,
                            columns[i].index,
@@ -312,7 +348,7 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
                            0,
                            NULL,
                            &columns[i].type);
-						   
+
 	columns[i].type_name = new unsigned char[(MAX_FIELD_SIZE)];
     
     //set the first byte of type_name to \0 instead of memsetting the entire buffer

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -331,7 +331,7 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
                            NULL,
                            &columns[i].scale);
 
-    //get column scale
+    //get column length
     ret = SQLColAttribute( hStmt,
                            columns[i].index,
                            SQL_DESC_LENGTH,

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -80,7 +80,11 @@ using namespace node;
 typedef struct {
   unsigned char *name;
   unsigned char *type_name;
-  unsigned int len;
+  unsigned int name_len;
+  SQLSMALLINT max_display_len;
+  SQLSMALLINT scale;
+  SQLSMALLINT precision;
+  SQLSMALLINT field_len;
   SQLLEN type;
   SQLUSMALLINT index;
 } Column;
@@ -260,6 +264,11 @@ struct query_request {
   if (info.Length() <= (I) || !info[I]->IsExternal())                   \
     return Nan::ThrowTypeError("Argument " #I " invalid");                \
   Local<External> VAR = Local<External>::Cast(info[I]);
+
+#define REQ_INT_ARG(I, VAR)                                             \
+  if (info.Length() <= (I) || !info[I]->IsInt32())                      \
+    return Nan::ThrowTypeError("Argument " #I " invalid");              \
+  SQLUSMALLINT VAR = (info[I]->Int32Value());
 
 #define OPT_INT_ARG(I, VAR, DEFAULT)                                    \
   SQLUSMALLINT VAR;                                                     \

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -787,6 +787,7 @@ NAN_METHOD(ODBCResult::GetColumnMetadata) {
     col->Set(Nan::New("SQL_DESC_DISPLAY_SIZE").ToLocalChecked(), Nan::New(self->columns[i].max_display_len));
     col->Set(Nan::New("SQL_DESC_PRECISION").ToLocalChecked(), Nan::New(self->columns[i].precision));
     col->Set(Nan::New("SQL_DESC_SCALE").ToLocalChecked(), Nan::New(self->columns[i].scale));
+    col->Set(Nan::New("SQL_DESC_LENGTH").ToLocalChecked(), Nan::New(self->columns[i].field_len));
 
     columns->Set(Nan::New(i), col);
   }

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -57,6 +57,7 @@ class ODBCResult : public Nan::ObjectWrap {
     static NAN_METHOD(FetchSync);
     static NAN_METHOD(FetchAllSync);
     static NAN_METHOD(GetColumnNamesSync);
+    static NAN_METHOD(GetColumnMetadata);
     
     //property getter/setters
     static NAN_GETTER(FetchModeGetter);


### PR DESCRIPTION
Column metadata is now available from the ODBCResult class. It can be accessed via the `getColumnMetadata` function.