### PR TITLE
Restrict createDbSync/dropDbSync on z/OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ ibmdb.debug(true);  // **==> ENABLE CONSOLE LOGS. <==**
 
 ### <a name="createDbSyncApi"></a> .createDbSync(dbName, connectionString, [options])
 
-To create a database (dbName) through node.js application.
+To create a database (dbName) through Node.js application.
 
 * **dbName** - The database name.
 * **connectionString** - The connection string for your database instance.
@@ -863,6 +863,9 @@ if(createDB) {
 }
 ```
 
+Note: This API is not supported for Db2 on z/OS servers.  Given that connection
+to Db2 on z/OS is to a specific subsystem, this API is not applicable.
+
 ### <a name="dropDbSyncApi"></a> .dropDbSync(dbName, connectionString)
 
 To drop a database (dbName) through node.js application.
@@ -883,6 +886,9 @@ if(dropDB) {
   console.log("Database dropped successfully.");
 }
 ```
+
+Note: This API is not supported for Db2 on z/OS servers.  Given that connection
+to Db2 on z/OS is to a specific subsystem, this API is not applicable.
 
 ## <a name="PoolAPIs"></a>Connection Pooling APIs
 

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -129,6 +129,19 @@ module.exports.openSync = function (connStr, options)
  */
 module.exports.createDbSync = function (dbName, connStr, options)
 {
+  // createDbSync API is not supported on z/OS:
+  // Databases are implemented/used in Db2 for z/OS differently than
+  // and Db2 for LUW.  A database in z/OS is simply a logical collection
+  // of table/index spaces that you create using the "CREATE DATABASE"
+  // SQL statement, while a database in LUW is conceptually equivalent
+  // to a subsystem in z/OS.  Connecting to a Db2 on z/OS subsystem
+  // entails a "database" is created already.  As such, this API is
+  // not applicable.
+  if (os.type() === "OS/390")
+  {
+    throw new Error("[node-ibm_db] createDbSync API is not supported on z/OS");
+  }
+
   var result;
   var db = new Database(options);
 
@@ -179,6 +192,19 @@ module.exports.createDbSync = function (dbName, connStr, options)
  */
 module.exports.dropDbSync = function (dbName, connStr, options)
 {
+  // dropDbSync API is not supported on z/OS:
+  // Databases are implemented/used in Db2 for z/OS differently than
+  // and Db2 for LUW.  A database in z/OS is simply a logical collection
+  // of table/index spaces that you create using the "CREATE DATABASE"
+  // SQL statement, while a database in LUW is conceptually equivalent
+  // to a subsystem in z/OS.  Connecting to a Db2 on z/OS subsystem
+  // entails a "database" is created already.  As such, this API is
+  // not applicable for Db2 on z/OS servers.
+  if (os.type() === "OS/390")
+  {
+    throw new Error("[node-ibm_db] dropDbSync API is not supported on z/OS");
+  }
+
   var result;
   var db = new Database(options);
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -570,6 +570,8 @@ NAN_METHOD(ODBCConnection::CloseSync) {
  * Creates a database with the specified name. Returns true if operation successful else false
  * "SQLCreateDb"
  *
+ * This function is not supported for Db2 for z/OS servers.
+ *
  * ===Parameters
  * 
  * connection handle
@@ -597,6 +599,17 @@ NAN_METHOD(ODBCConnection::CreateDbSync) {
    DEBUG_PRINTF("ODBCConnection::CreateDbSync\n");
    Nan::HandleScope scope;
 
+#ifdef __MVS__
+   // createDbSync API is not supported on z/OS:
+   // Databases are implemented/used in Db2 for z/OS differently than
+   // and Db2 for LUW.  A database in z/OS is simply a logical collection
+   // of table/index spaces that you create using the "CREATE DATABASE"
+   // SQL statement, while a database in LUW is conceptually equivalent
+   // to a subsystem in z/OS.  Connecting to a Db2 on z/OS subsystem
+   // entails a "database" is created already.  As such, this API is
+   // not applicable for Db2 on z/OS servers.
+   info.GetReturnValue().Set(Nan::False());
+#else
    ODBCConnection* conn = Nan::ObjectWrap::Unwrap<ODBCConnection>(info.Holder());
 
    SQLRETURN ret;
@@ -701,6 +714,7 @@ NAN_METHOD(ODBCConnection::CreateDbSync) {
    else {
      info.GetReturnValue().Set(Nan::True());
    }
+#endif // __MVS__
 }
 
 /*  */
@@ -710,6 +724,8 @@ NAN_METHOD(ODBCConnection::CreateDbSync) {
  * ===Description
  * Drops a database with the specified name. Returns true if operation successful else false
  * "SQLDropDb"
+ *
+ * This function is not supported for Db2 for z/OS servers.
  *
  * ===Parameters
  * 
@@ -727,6 +743,17 @@ NAN_METHOD(ODBCConnection::DropDbSync) {
    DEBUG_PRINTF("ODBCConnection::DropDbSync\n");
    Nan::HandleScope scope;
 
+#ifdef __MVS__
+   // createDbSync API is not supported on z/OS:
+   // Databases are implemented/used in Db2 for z/OS differently than
+   // and Db2 for LUW.  A database in z/OS is simply a logical collection
+   // of table/index spaces that you create using the "CREATE DATABASE"
+   // SQL statement, while a database in LUW is conceptually equivalent
+   // to a subsystem in z/OS.  Connecting to a Db2 on z/OS subsystem
+   // entails a "database" is created already.  As such, this API is
+   // not applicable for Db2 on z/OS servers.
+   info.GetReturnValue().Set(Nan::False());
+#else
    ODBCConnection* conn = Nan::ObjectWrap::Unwrap<ODBCConnection>(info.Holder());
 
    SQLRETURN ret;
@@ -781,6 +808,7 @@ NAN_METHOD(ODBCConnection::DropDbSync) {
    else {
      info.GetReturnValue().Set(Nan::True());
    }
+#endif
 }
 
 /*


### PR DESCRIPTION
The createDbSync and dropDbSync APIs are not applicable to z/OS.
Update the API to throw an error on z/OS if the APIs are invoked.

The reason that they are not supported is because there is a
fundamental difference in how a database is implemented/used
in Db2 for z/OS and Db2 for LUW.  A database in z/OS is simply
a logical collection of table/index spaces that you create
using the "CREATE DATABASE" SQL statement.  A database in LUW
is conceptually equivalent to a subsystem in z/OS.  When working
with Db2 for LUW, you connect to a specific database, whereas
in Db2 for z/OS, you connect to a Db2 subsystem.  So, if the
purpose of using SQLCreateDb is to create a database, so that
you can connect to it later, creating a database on z/OS will
not serve that purpose.

DCO 1.1 Signed-off-by: Joran Siu <joransiu@ca.ibm.com>