### PR TITLE
Update basic + async call tests for z/OS compatibility

### DIFF
--- a/test/test-basic-test.js
+++ b/test/test-basic-test.js
@@ -14,12 +14,25 @@ ibmdb.open(cn, {"fetchMode": 3}, function(err, conn) { // 3 means FETCH_ARRARY
     } catch (e) {}
   conn.querySync("create table mytab1 (c1 int, c2 varchar(10))");
   conn.querySync("insert into mytab1 values ( 4, 'für')");
-  conn.query('select 1, 4, 5 from sysibm.sysdummy1;' +
-             'select * from mytab1 where c1 = 2;'+
-             'select 3,7,8 from sysibm.sysdummy1', [23], function (err, data) {
-    if (err) console.log(err);
-    else {
-      console.log( data);
+  conn.query('select 1, 4, 5 from sysibm.sysdummy1;', function (err, data) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log(data);
+      conn.query('select * from mytab1 where c1 = 2;', function (err, data) {
+        if (err) {
+          console.log(err);
+        } else {
+          console.log(data);
+          conn.query('select 3,7,8 from sysibm.sysdummy1', [23], function (err, data) {
+            if (err) {
+              console.log(err);
+            } else {
+              console.log( data);
+            }
+          });
+        }
+      });
     }
   });
   var d=conn.querySync("select * from mytab1 where (UCASE(C2) LIKE '%FUR%' OR UCASE(C2) LIKE '%FüR%') FOR READ ONLY WITH UR OPTIMIZE FOR 50 ROWS");

--- a/test/test-call-async.js
+++ b/test/test-call-async.js
@@ -66,12 +66,12 @@ ibmdb.open(cn, function (err, conn)
       } catch (e) { }
       conn.querySync("create procedure " + schema + ".PROC2 (IN v1 INTEGER) disable debug mode BEGIN END");
     } else {
-      conn.querySync("create or replace procedure " + schema + ".proc2 (IN v1 INTEGER) BEGIN END");
+      conn.querySync("create or replace procedure " + schema + ".PROC2 (IN v1 INTEGER) BEGIN END");
     }
-    query = "call " + schema + ".proc2(?)";
+    query = "call " + schema + ".PROC2(?)";
     conn.query({"sql":query, "params" : [param1]}, function(err, result){
         if(err) console.log(err);
-        conn.querySync("drop procedure " + schema + ".proc2(INT)");
+        conn.querySync("drop procedure " + schema + ".PROC2(INT)");
         conn.closeSync();
         assert.equal(result.length, 0);
         console.log('done');


### PR DESCRIPTION
Introduce minor test changes to test-basic-test and test-call-async
to improve compatibility with z/OS.

- Separate multi-row inserts and combined selects (not supported for z/OS)
- Capitalize procedure names

DCO 1.1 Signed-off-by: Joran Siu joransiu@ca.ibm.com