### PR TITLE
Remove extraneous comma in zOS test config

### DIFF
--- a/test/config.testConnectionStrings.zos.json
+++ b/test/config.testConnectionStrings.zos.json
@@ -1,4 +1,4 @@
 { "DSN" : "SAMPLE",
   "UID" : "newton",
-  "PWD" : "db2admin",
+  "PWD" : "db2admin"
 }


### PR DESCRIPTION
An extra comma after the last property in
config.testConnectionStrings.zos.json prevents it from being
properly loaded in test/common.js.

DCO 1.1 Signed-off-by: Joran Siu <joransiu@ca.ibm.com>