### PR TITLE
Fix STEPLIB typos for SDSNLOD2 library

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -264,7 +264,7 @@ Please refer to the [ODBC Guide and References](https://www.ibm.com/support/know
 
     ```sh
     # Assumes IBM_DB_HOME specifies the HLQ of the Db2 datasets.
-    export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME:SDSNL0D2
+    export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME.SDSNLOD2
     ```
 
 4. Configured an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Please refer to the [ODBC Guide and References](https://www.ibm.com/support/know
 
     ```sh
     # Assumes IBM_DB_HOME specifies the HLQ of the Db2 datasets.
-    export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME:SDSNL0D2  
+    export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME.SDSNLOD2
     ```
 
 4. Configure an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:


### PR DESCRIPTION
README.md and INSTALL.md had incorrect typos for STEPLIB environment
variable to reference the Db2 SDSNLOD2 library.

DCO 1.1 Signed-off-by: Joran Siu <joransiu@ca.ibm.com>