### PR TITLE
Enable electron build for use with VS Code

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,7 +298,7 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
-		console.log('\nProceeding with building of IBM_DB to work with Electron framework...\n');
+		console.log('\nProceeding with building of IBM_DB to work with Electron framework...');
 		let vscodeVer, electronVer = "2.0.12";
 
 		try{
@@ -332,7 +332,7 @@ var install_node_ibm_db = function(file_url) {
 			console.log('Unable to detect VS Code version');
 		}
 		
-		console.log(`Will use Electron version ${electronVer} for build...`)
+		console.log(`Using Electron version ${electronVer} for build...`)
 		
         var buildString = "node-gyp configure build ";
 
@@ -342,7 +342,8 @@ var install_node_ibm_db = function(file_url) {
             buildString = buildString + " --IS_DOWNLOADED=false";
         }
 		
-		buildString = buildString + " --target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron ";
+		buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;
+		console.log(buildString);
 
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -332,7 +332,7 @@ var install_node_ibm_db = function(file_url) {
 			console.log('Unable to detect VS Code version');
 		}
 		
-		console.log(`Will use Electron version ${electronVer} for build...`
+		console.log(`Will use Electron version ${electronVer} for build...`)
 		
         var buildString = "node-gyp configure build ";
 

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,7 +298,42 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
-		console.log('\nProceeding with building of IBM_DB to work with Electron framework\n');
+		console.log('\nProceeding with building of IBM_DB to work with Electron framework...\n');
+		let vscodeVer, electronVer = "2.0.12";
+
+		try{
+			let codeOut = execSync('code --version').toString();
+
+			vscodeVer = parseFloat(codeOut.split('\n')[0]);
+
+			if(vscodeVer >= 1.31)
+			{
+				electronVer = "3.1.2"
+			}
+			else if(vscodeVer == 1.30){
+				electronVer = "3.0.0"
+			}
+			else if(vscodeVer == 1.29){
+				electronVer = "2.0.12"
+			}		
+			else if(vscodeVer == 1.28){
+				electronVer = "2.0.9"
+			}
+			else if(vscodeVer == 1.26 || vscodeVer == 1.27){
+				electronVer = "2.0.5"
+			}
+			else{
+				//nothing
+			}
+			
+			console.log(`Detected VS Code version ${vscodeVer}`);
+		}
+		catch(e){
+			console.log('Unable to detect VS Code version');
+		}
+		
+		console.log(`Will use Electron version ${electronVer} for build...`
+		
         var buildString = "node-gyp configure build ";
 
         if(isDownloaded) {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -309,7 +309,7 @@ var install_node_ibm_db = function(file_url) {
         //Build triggered from the VSCode extension
         if(process.env.npm_config_vscode){
             console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
-            let vscodeVer, electronVer = "3.0.0";
+            let vscodeVer = 0, electronVer = "3.0.0";
 
             try{
                 let codeOut = execSync('code --version').toString();
@@ -332,9 +332,12 @@ var install_node_ibm_db = function(file_url) {
                     electronVer = "2.0.5"
                 }
                 else{
-                    console.log('You are probably running an old version of VS Code. Kindly update to latest version');
-                }				
-                console.log(`Detected VS Code version ${vscodeVer}`);
+                    console.log('Either VS Code is not installed on your system or you are probably having an old version. Install the latest version of VS Code');
+                }
+
+                if(!isNaN(vscodeVer)){
+                    console.log(`Detected VS Code version ${vscodeVer}`);
+                }
             }
             catch(e){
                 console.log('Unable to detect VS Code version');

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -300,16 +300,17 @@ var install_node_ibm_db = function(file_url) {
     {
         var buildString = "node-gyp configure build ";
 
-        if(isDownloaded) {
+/*         if(isDownloaded) {
             buildString = buildString + " --IS_DOWNLOADED=true";
         } else {
             buildString = buildString + " --IS_DOWNLOADED=false";
-        }
+        } */
 
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
         {
-            var buildString = buildString + " --IBM_DB_HOME=\$IBM_DB_HOME";
+			console.log('\nProceeding with building of ibm_db for Electron\n');
+            var buildString = buildString + "--target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron --msvs_version=2015 --IBM_DB_HOME=\$IBM_DB_HOME  --IS_DOWNLOADED=true";
 
             var childProcess = exec(buildString, function (error, stdout, stderr)
             {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,7 +298,12 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
-		console.log(process.env);
+		if(process.env.npm_config_vscode){
+			console.log('captured')
+		}
+		else{
+			console.log(process.env.npm_config_vscode);
+		}
 		console.log('\nProceeding to build IBM_DB for Electron framework...');
 		let vscodeVer, electronVer = "3.0.0";
 

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,7 +298,7 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
-		console.log(process.ENV);
+		console.log(process.env);
 		console.log('\nProceeding to build IBM_DB for Electron framework...');
 		let vscodeVer, electronVer = "3.0.0";
 

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -300,17 +300,17 @@ var install_node_ibm_db = function(file_url) {
     {
         var buildString = "node-gyp configure build ";
 
-/*         if(isDownloaded) {
+        if(isDownloaded) {
             buildString = buildString + " --IS_DOWNLOADED=true";
         } else {
             buildString = buildString + " --IS_DOWNLOADED=false";
-        } */
+        }
 
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
         {
 			console.log('\nProceeding with building of ibm_db for Electron\n');
-            var buildString = buildString + "--target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron --msvs_version=2015 --IBM_DB_HOME=\$IBM_DB_HOME  --IS_DOWNLOADED=true";
+            var buildString = buildString + "--target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron --msvs_version=2015 --IBM_DB_HOME=\$IBM_DB_HOME ";
 
             var childProcess = exec(buildString, function (error, stdout, stderr)
             {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -305,12 +305,14 @@ var install_node_ibm_db = function(file_url) {
         } else {
             buildString = buildString + " --IS_DOWNLOADED=false";
         }
+		
+		buildString = buildString + " --target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron --msvs_version=2015 ";
 
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
         {
 			console.log('\nProceeding with building of ibm_db for Electron\n');
-            var buildString = buildString + "--target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron --msvs_version=2015 --IBM_DB_HOME=\$IBM_DB_HOME ";
+            var buildString = buildString + " --IBM_DB_HOME=\$IBM_DB_HOME ";
 
             var childProcess = exec(buildString, function (error, stdout, stderr)
             {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,8 +298,8 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
-		console.log('\nProceeding with building of IBM_DB to work with Electron framework...');
-		let vscodeVer, electronVer = "2.0.12";
+		console.log('\nProceeding to build IBM_DB for Electron framework...');
+		let vscodeVer, electronVer = "3.0.0";
 
 		try{
 			let codeOut = execSync('code --version').toString();
@@ -342,8 +342,7 @@ var install_node_ibm_db = function(file_url) {
             buildString = buildString + " --IS_DOWNLOADED=false";
         }
 		
-		buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;
-		console.log(buildString);
+		buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;		
 
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,7 +298,7 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
-		console.log('\nProceeding with building of ibm_db for Electron\n');
+		console.log('\nProceeding with building of IBM_DB to work with Electron framework\n');
         var buildString = "node-gyp configure build ";
 
         if(isDownloaded) {
@@ -424,6 +424,7 @@ var install_node_ibm_db = function(file_url) {
         else
         {
             var buildString = buildString + " --IBM_DB_HOME=\"$IBM_DB_HOME\"";
+			console.log(buildString);
             var childProcess = exec(buildString, function (error, stdout, stderr) {
                 console.log(stdout);
                 if (error !== null) {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,6 +298,7 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
+		console.log('\nProceeding with building of ibm_db for Electron\n');
         var buildString = "node-gyp configure build ";
 
         if(isDownloaded) {
@@ -311,7 +312,7 @@ var install_node_ibm_db = function(file_url) {
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
         {
-			console.log('\nProceeding with building of ibm_db for Electron\n');
+			
             var buildString = buildString + " --IBM_DB_HOME=\$IBM_DB_HOME ";
 
             var childProcess = exec(buildString, function (error, stdout, stderr)

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -297,49 +297,7 @@ var install_node_ibm_db = function(file_url) {
     }
 
     function buildBinary(isDownloaded) 
-    {
-		if(process.env.npm_config_vscode){
-			console.log('captured')
-		}
-		else{
-			console.log(process.env.npm_config_vscode);
-		}
-		console.log('\nProceeding to build IBM_DB for Electron framework...');
-		let vscodeVer, electronVer = "3.0.0";
-
-		try{
-			let codeOut = execSync('code --version').toString();
-
-			vscodeVer = parseFloat(codeOut.split('\n')[0]);
-
-			if(vscodeVer >= 1.31)
-			{
-				electronVer = "3.1.2"
-			}
-			else if(vscodeVer == 1.30){
-				electronVer = "3.0.0"
-			}
-			else if(vscodeVer == 1.29){
-				electronVer = "2.0.12"
-			}		
-			else if(vscodeVer == 1.28){
-				electronVer = "2.0.9"
-			}
-			else if(vscodeVer == 1.26 || vscodeVer == 1.27){
-				electronVer = "2.0.5"
-			}
-			else{
-				//nothing
-			}
-			
-			console.log(`Detected VS Code version ${vscodeVer}`);
-		}
-		catch(e){
-			console.log('Unable to detect VS Code version');
-		}
-		
-		console.log(`Using Electron version ${electronVer} for build...`)
-		
+    {		
         var buildString = "node-gyp configure build ";
 
         if(isDownloaded) {
@@ -348,8 +306,44 @@ var install_node_ibm_db = function(file_url) {
             buildString = buildString + " --IS_DOWNLOADED=false";
         }
 		
-		buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;		
+		//Build triggered from the VSCode extension
+		if(process.env.npm_config_vscode){			
+			console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
+			let vscodeVer, electronVer = "3.0.0";
 
+			try{
+				let codeOut = execSync('code --version').toString();
+				vscodeVer = parseFloat(codeOut.split('\n')[0]);
+
+				if(vscodeVer >= 1.31)
+				{
+					electronVer = "3.1.2"
+				}
+				else if(vscodeVer == 1.30){
+					electronVer = "3.0.0"
+				}
+				else if(vscodeVer == 1.29){
+					electronVer = "2.0.12"
+				}		
+				else if(vscodeVer == 1.28){
+					electronVer = "2.0.9"
+				}
+				else if(vscodeVer == 1.26 || vscodeVer == 1.27){
+					electronVer = "2.0.5"
+				}
+				else{
+					//nothing
+				}
+				
+				console.log(`Detected VS Code version ${vscodeVer}`);				
+			}
+			catch(e){
+				console.log('Unable to detect VS Code version');
+			}
+			console.log(`Using Electron version ${electronVer}`);
+			buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;		
+		}		
+				
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
         {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -306,7 +306,7 @@ var install_node_ibm_db = function(file_url) {
             buildString = buildString + " --IS_DOWNLOADED=false";
         }
 		
-		buildString = buildString + " --target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron --msvs_version=2015 ";
+		buildString = buildString + " --target=3.1.2 --arch=x64 --dist-url=https://atom.io/download/electron ";
 
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -297,57 +297,56 @@ var install_node_ibm_db = function(file_url) {
     }
 
     function buildBinary(isDownloaded) 
-    {		
+    {
         var buildString = "node-gyp configure build ";
 
         if(isDownloaded) {
             buildString = buildString + " --IS_DOWNLOADED=true";
         } else {
             buildString = buildString + " --IS_DOWNLOADED=false";
-        }
+        }		
 		
 		//Build triggered from the VSCode extension
-		if(process.env.npm_config_vscode){
-			console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
+        if(process.env.npm_config_vscode){
+            console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
 			let vscodeVer, electronVer = "3.0.0";
 
-			try{
-				let codeOut = execSync('code --version').toString();
-				vscodeVer = parseFloat(codeOut.split('\n')[0]);
+            try{
+                let codeOut = execSync('code --version').toString();
+                vscodeVer = parseFloat(codeOut.split('\n')[0]);
 
-				if(vscodeVer >= 1.31)
-				{
-					electronVer = "3.1.2";
-				}
-				else if(vscodeVer == 1.30){
-					electronVer = "3.0.0";
-				}
-				else if(vscodeVer == 1.29){
-					electronVer = "2.0.12";
-				}
-				else if(vscodeVer == 1.28){
-					electronVer = "2.0.9";
-				}
-				else if(vscodeVer == 1.26 || vscodeVer == 1.27){
-					electronVer = "2.0.5"
-				}
-				else{
-					//nothing
-				}
+                if(vscodeVer >= 1.31)
+                {
+                    electronVer = "3.1.2";
+                }
+                else if(vscodeVer == 1.30){
+                    electronVer = "3.0.0";
+                }
+                else if(vscodeVer == 1.29){
+                    electronVer = "2.0.12";
+                }
+                else if(vscodeVer == 1.28){
+                    electronVer = "2.0.9";
+                }
+                else if(vscodeVer == 1.26 || vscodeVer == 1.27){
+                    electronVer = "2.0.5"
+                }
+                else{
+					console.log('You are probably running an old version of VS Code. Kindly update to latest version');
+                }
 				
-				console.log(`Detected VS Code version ${vscodeVer}`);
-			}
-			catch(e){
-				console.log('Unable to detect VS Code version');
-			}
-			console.log(`Using Electron version ${electronVer}`);
-			buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;
-		}
+                console.log(`Detected VS Code version ${vscodeVer}`);
+            }
+            catch(e){
+                console.log('Unable to detect VS Code version');
+            }
+            console.log(`Using Electron version ${electronVer}`);
+            buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;
+        }
 				
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
-        {
-			
+        {			
             var buildString = buildString + " --IBM_DB_HOME=\$IBM_DB_HOME ";
 
             var childProcess = exec(buildString, function (error, stdout, stderr)
@@ -458,8 +457,7 @@ var install_node_ibm_db = function(file_url) {
 
         else
         {
-            var buildString = buildString + " --IBM_DB_HOME=\"$IBM_DB_HOME\"";
-			console.log(buildString);
+            var buildString = buildString + " --IBM_DB_HOME=\"$IBM_DB_HOME\"";			
             var childProcess = exec(buildString, function (error, stdout, stderr) {
                 console.log(stdout);
                 if (error !== null) {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -308,7 +308,7 @@ var install_node_ibm_db = function(file_url) {
 
 			if(vscodeVer >= 1.31)
 			{
-				electronVer = "3.0.0"
+				electronVer = "3.1.2"
 			}
 			else if(vscodeVer == 1.30){
 				electronVer = "3.0.0"

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -298,6 +298,7 @@ var install_node_ibm_db = function(file_url) {
 
     function buildBinary(isDownloaded) 
     {
+		console.log(process.ENV);
 		console.log('\nProceeding to build IBM_DB for Electron framework...');
 		let vscodeVer, electronVer = "3.0.0";
 

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -306,7 +306,7 @@ var install_node_ibm_db = function(file_url) {
             buildString = buildString + " --IS_DOWNLOADED=false";
         }
 
-		//Build triggered from the VSCode extension
+        //Build triggered from the VSCode extension
         if(process.env.npm_config_vscode){
             console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
             let vscodeVer, electronVer = "3.0.0";
@@ -333,8 +333,7 @@ var install_node_ibm_db = function(file_url) {
                 }
                 else{
                     console.log('You are probably running an old version of VS Code. Kindly update to latest version');
-                }
-				
+                }				
                 console.log(`Detected VS Code version ${vscodeVer}`);
             }
             catch(e){

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -308,7 +308,7 @@ var install_node_ibm_db = function(file_url) {
 
 			if(vscodeVer >= 1.31)
 			{
-				electronVer = "3.1.2"
+				electronVer = "3.0.0"
 			}
 			else if(vscodeVer == 1.30){
 				electronVer = "3.0.0"

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -304,12 +304,12 @@ var install_node_ibm_db = function(file_url) {
             buildString = buildString + " --IS_DOWNLOADED=true";
         } else {
             buildString = buildString + " --IS_DOWNLOADED=false";
-        }		
-		
+        }
+
 		//Build triggered from the VSCode extension
         if(process.env.npm_config_vscode){
             console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
-			let vscodeVer, electronVer = "3.0.0";
+            let vscodeVer, electronVer = "3.0.0";
 
             try{
                 let codeOut = execSync('code --version').toString();
@@ -332,7 +332,7 @@ var install_node_ibm_db = function(file_url) {
                     electronVer = "2.0.5"
                 }
                 else{
-					console.log('You are probably running an old version of VS Code. Kindly update to latest version');
+                    console.log('You are probably running an old version of VS Code. Kindly update to latest version');
                 }
 				
                 console.log(`Detected VS Code version ${vscodeVer}`);
@@ -343,11 +343,11 @@ var install_node_ibm_db = function(file_url) {
             console.log(`Using Electron version ${electronVer}`);
             buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;
         }
-				
+
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')
-        {			
-            var buildString = buildString + " --IBM_DB_HOME=\$IBM_DB_HOME ";
+        {
+            var buildString = buildString + " --IBM_DB_HOME=\$IBM_DB_HOME";
 
             var childProcess = exec(buildString, function (error, stdout, stderr)
             {
@@ -457,7 +457,7 @@ var install_node_ibm_db = function(file_url) {
 
         else
         {
-            var buildString = buildString + " --IBM_DB_HOME=\"$IBM_DB_HOME\"";			
+            var buildString = buildString + " --IBM_DB_HOME=\"$IBM_DB_HOME\"";
             var childProcess = exec(buildString, function (error, stdout, stderr) {
                 console.log(stdout);
                 if (error !== null) {

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -307,7 +307,7 @@ var install_node_ibm_db = function(file_url) {
         }
 		
 		//Build triggered from the VSCode extension
-		if(process.env.npm_config_vscode){			
+		if(process.env.npm_config_vscode){
 			console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
 			let vscodeVer, electronVer = "3.0.0";
 
@@ -317,16 +317,16 @@ var install_node_ibm_db = function(file_url) {
 
 				if(vscodeVer >= 1.31)
 				{
-					electronVer = "3.1.2"
+					electronVer = "3.1.2";
 				}
 				else if(vscodeVer == 1.30){
-					electronVer = "3.0.0"
+					electronVer = "3.0.0";
 				}
 				else if(vscodeVer == 1.29){
-					electronVer = "2.0.12"
-				}		
+					electronVer = "2.0.12";
+				}
 				else if(vscodeVer == 1.28){
-					electronVer = "2.0.9"
+					electronVer = "2.0.9";
 				}
 				else if(vscodeVer == 1.26 || vscodeVer == 1.27){
 					electronVer = "2.0.5"
@@ -335,14 +335,14 @@ var install_node_ibm_db = function(file_url) {
 					//nothing
 				}
 				
-				console.log(`Detected VS Code version ${vscodeVer}`);				
+				console.log(`Detected VS Code version ${vscodeVer}`);
 			}
 			catch(e){
 				console.log('Unable to detect VS Code version');
 			}
 			console.log(`Using Electron version ${electronVer}`);
-			buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;		
-		}		
+			buildString = buildString + ` --target=${electronVer} --arch=x64 --dist-url=https://atom.io/download/electron `;
+		}
 				
         // Windows : Auto Installation Process -> 1) node-gyp then 2) msbuild.
         if( platform == 'win32' && arch == 'x64')


### PR DESCRIPTION
This change is to enable building IBM_DB with Electron framework headers if "-vscode" option is provided during installation.
Appropriate version of Electron framework is chosen based on the detected VS Code version.

Thanks,
Vyshakh