### PR TITLE
Vscode extension detection during install

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -307,8 +307,8 @@ var install_node_ibm_db = function(file_url) {
         }
 
         //Build triggered from the VSCode extension
-        if(process.env.npm_config_vscode){
-            console.log('\nVSCode flag enabled, proceeding to build IBM_DB for Electron framework...');
+        if((process.env.npm_config_vscode)||(__dirname.indexOf('vscode-db2connect')!=-1)){			
+            console.log('\nProceeding to build IBM_DB for Electron framework...');
             let vscodeVer = 0, electronVer = "3.0.0";
 
             try{


### PR DESCRIPTION
With this change, if either '-vscode' flag is mentioned during npm install or if the installation is happening within a folder called 'vscode-db2connect' then it would build ibm_db for electron framework.
This is to make installation of ibm_db from within vscode seamless.