### PR TITLE
Checking for directory name with 'db2connect' as substring

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -310,7 +310,7 @@ var install_node_ibm_db = function(file_url) {
         removeDir('build');
 
         //Build triggered from the VSCode extension
-        if((process.env.npm_config_vscode)||(__dirname.indexOf('vscode-db2connect')!=-1)){			
+        if((process.env.npm_config_vscode)||(__dirname.toLowerCase().indexOf('db2connect')!=-1)){
             console.log('\nProceeding to build IBM_DB for Electron framework...');
             var vscodeVer = 0, electronVer = "3.0.0";
 


### PR DESCRIPTION
The VSCode extension for Db2Connect was renamed to "Db2Connet" from 'vscode-db2connect'.
This change is to reflect that change during installtion

Thanks,
Vyshakh