### PR TITLE
Update z/OS documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -263,11 +263,11 @@ Please refer to the [ODBC Guide and References](https://www.ibm.com/support/know
 
 2. Binded the ODBC packages.  A sample JCL is provided in the `SDSNSAMP` dataset in member `DSNTIJCL`.  Customize the JCL with specifics to your system.
 
-3. Set the `IBM_DB_HOME` environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSN1210.SDSNC.H` and `DSN1210.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSN1210` with the following statement (can be saved in `~/.profile`):
+3. Set the `IBM_DB_HOME` environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSNC10.SDSNC.H` and `DSNC10.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSNC10` with the following statement (can be saved in `~/.profile`):
 
     ```sh
     # Set HLQ to Db2 datasets.
-    export IBM_DB_HOME="DSN1210"
+    export IBM_DB_HOME="DSNC10"
     ```
 
 4. Update the `STEPLIB` environment variable to include the Db2 SDSNEXIT, SDSNLOAD and SDSNLOD2 data sets. You can set the `STEPLIB` environment variable with the following statement, after defining `IBM_DB_HOME` to the high level qualifier of your Db2 datasets as instructed above:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -253,33 +253,45 @@ It's Done.
 
 ### 8.1 Install Node.js for z/OS
 
-Download and install the IBM SDK for Node.js - z/OS from [Marketplace](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos).  Trial version of IBM SDK for Node.js - z/OS is also available on [DevelopWorks](https://developer.ibm.com/node/sdk/ztp/).  Given that ibm_db includes native add-on code, ensure that you have the pre-requisite Python and Make tools installed as detailed in the SDK installation instructions.
+Download and install the IBM SDK for Node.js - z/OS from [Marketplace](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos/purchase).  Given that ibm_db includes native add-on code, ensure that you have the pre-requisite Python and Make tools installed as detailed in the SDK installation instructions.
 
 ### 8.2 Configure ODBC driver on z/OS
 
 Please refer to the [ODBC Guide and References](https://www.ibm.com/support/knowledgecenter/SSEPEK/pdf/db2z_12_odbcbook.pdf) cookbook for how to configure your ODBC driver.   Specifically, you need to ensure you have:
 
-1. Binded the ODBC packages.  A sample JCL is provided in the `SDSNSAMP` dataset in member `DSNTIJCL`.  Customize the JCL with specifics to your system.
+1. Apply Db2 on z/OS PTF [UI60551](https://www-01.ibm.com/support/docview.wss?uid=swg1PH05953) to pick up new ODBC functionality to support Node.js applications.
 
-2. Set the `IBM_DB_HOME` environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSN1210.SDSNC.H` and `DSN1210.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSN1210` with the following statement (can be saved in `~/.profile`):
+2. Binded the ODBC packages.  A sample JCL is provided in the `SDSNSAMP` dataset in member `DSNTIJCL`.  Customize the JCL with specifics to your system.
+
+3. Set the `IBM_DB_HOME` environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSN1210.SDSNC.H` and `DSN1210.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSN1210` with the following statement (can be saved in `~/.profile`):
 
     ```sh
     # Set HLQ to Db2 datasets.
     export IBM_DB_HOME="DSN1210"
     ```
 
-3. Update the `STEPLIB` environment variable to include the Db2 SDSNEXIT, SDSNLOAD and SDSNLOD2 data sets. You can set the `STEPLIB` environment variable with the following statement, after defining `IBM_DB_HOME` to the high level qualifier of your Db2 datasets as instructed above:
+4. Update the `STEPLIB` environment variable to include the Db2 SDSNEXIT, SDSNLOAD and SDSNLOD2 data sets. You can set the `STEPLIB` environment variable with the following statement, after defining `IBM_DB_HOME` to the high level qualifier of your Db2 datasets as instructed above:
 
     ```sh
     # Assumes IBM_DB_HOME specifies the HLQ of the Db2 datasets.
     export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME.SDSNLOD2
     ```
 
-4. Configured an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:
+5. Configured an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:
+
+
+    In COMMON section:
 
     ```
-    MULTICONTEXT=1
+    MULTICONTEXT=2
     CURRENTAPPENSCH=ASCII
+    FLOAT=IEEE
+    ```
+
+    In SUBSYSTEM section:
+
+    ```
+    MVSATTACHTYPE=RRSAF
     ```
 
     Here is a sample of a complete initialization file:
@@ -290,8 +302,9 @@ Please refer to the [ODBC Guide and References](https://www.ibm.com/support/know
     [COMMON]
     MVSDEFAULTSSID=VC1A
     CONNECTTYPE=1
-    MULTICONTEXT=1
+    MULTICONTEXT=2
     CURRENTAPPENSCH=ASCII
+    FLOAT=IEEE
     ; Example SUBSYSTEM stanza for VC1A subsystem
     [VC1A]
     MVSATTACHTYPE=RRSAF

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install a newer compiler or upgrade older one.
 
 - On distributed platforms, you do need not to install any Db2 ODBC client driver for connectivity. `ibm_db` itself downloads and installs an odbc/cli driver from IBM website during installation. Just install `ibm_db` and it is ready for use.
 
-- On z/OS, ODBC driver support is part of IBM Db2 for z/OS 11.0 and 12.0.  Please ensure IBM Db2 for z/OS 11.0 or 12.0 is installed on your given LPAR.  Ensure you follow the instructions to configure your ODBC driver [here](#configure-odbc-driver-on-z/os).
+- On z/OS, ODBC driver support is part of IBM Db2 for z/OS 11.0 and 12.0.  Please ensure IBM Db2 for z/OS 11.0 or 12.0 is installed on your given LPAR.  Ensure you follow the instructions to configure your ODBC driver [here](#configure-odbc-driver-on-zos).
 
 - On z/OS only certain versions of node-gyp are supported. This was tested with:<br>
 node-gyp 3.4.0<br>
@@ -86,11 +86,13 @@ npm install ibm_db
 
 ### Configure ODBC driver on z/OS
 
-Please refer to the [ODBC Guide and References](https://www.ibm.com/support/knowledgecenter/SSEPEK/pdf/db2z_12_odbcbook.pdf) cookbook for how to configure your ODBC driver.   Specifically, you need to ensure you:
+Please refer to the [ODBC Guide and References](https://www.ibm.com/support/knowledgecenter/SSEPEK/pdf/db2z_12_odbcbook.pdf) cookbook for how to configure your ODBC driver.   Specifically, you need to:
 
-1. Bind the ODBC packages.  A sample JCL is provided in the `SDSNSAMP` dataset in member `DSNTIJCL`.  Customize the JCL with specifics to your system.
+1. Apply Db2 on z/OS PTF [UI60551](https://www-01.ibm.com/support/docview.wss?uid=swg1PH05953) to pick up new ODBC functionality to support Node.js applications.
 
-2. Ensure users that should be authorized have authority to execute the DSNACLI plan.  Included are samples granting authority to public (all users), or specific groups via SQL GRANT statements, or alternately via RACF.  The security administrator can use these samples as a model and customize/translate to your installation security standards as appropriate.
+2. Bind the ODBC packages.  A sample JCL is provided in the `SDSNSAMP` dataset in member `DSNTIJCL`.  Customize the JCL with specifics to your system.
+
+3. Ensure users that should be authorized have authority to execute the DSNACLI plan.  Included are samples granting authority to public (all users), or specific groups via SQL GRANT statements, or alternately via RACF.  The security administrator can use these samples as a model and customize/translate to your installation security standards as appropriate.
 
     **Examples using SQL GRANT statement**:
 
@@ -121,18 +123,27 @@ Please refer to the [ODBC Guide and References](https://www.ibm.com/support/know
          SETR RACLIST(MDSNPN) REFRESH
 
 
-3. Update the `STEPLIB` environment variable to include the Db2 SDSNEXIT, SDSNLOAD and SDSNLOD2 data sets. You can set the `STEPLIB `environment variable in your `.profile` with the following statement, after defining `IBM_DB_HOME` to the high level qualifier of your Db2 datasets as instructed above:
+4. Update the `STEPLIB` environment variable to include the Db2 SDSNEXIT, SDSNLOAD and SDSNLOD2 data sets. You can set the `STEPLIB `environment variable in your `.profile` with the following statement, after defining `IBM_DB_HOME` to the high level qualifier of your Db2 datasets as instructed above:
 
     ```sh
     # Assumes IBM_DB_HOME specifies the HLQ of the Db2 datasets.
     export STEPLIB=$STEPLIB:$IBM_DB_HOME.SDSNEXIT:$IBM_DB_HOME.SDSNLOAD:$IBM_DB_HOME.SDSNLOD2
     ```
 
-4. Configure an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:
+5. Configure an appropriate _Db2 ODBC initialization file_ that can be read at application time. You can specify the file by using either a DSNAOINI data definition statement or by defining a `DSNAOINI` z/OS UNIX environment variable.  For compatibility with ibm_db, the following properties must be set:
+
+    In COMMON section:
 
     ```
-    MULTICONTEXT=1
+    MULTICONTEXT=2
     CURRENTAPPENSCH=ASCII
+    FLOAT=IEEE
+    ```
+
+    In SUBSYSTEM section:
+
+    ```
+    MVSATTACHTYPE=RRSAF
     ```
 
     Here is a sample of a complete initialization file:
@@ -143,8 +154,9 @@ Please refer to the [ODBC Guide and References](https://www.ibm.com/support/know
     [COMMON]
     MVSDEFAULTSSID=VC1A
     CONNECTTYPE=1
-    MULTICONTEXT=1
+    MULTICONTEXT=2
     CURRENTAPPENSCH=ASCII
+    FLOAT=IEEE
     ; Example SUBSYSTEM stanza for VC1A subsystem
     [VC1A]
     MVSATTACHTYPE=RRSAF

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install ibm_db
 
 - HOW:
 	- On distributed platforms, set **IBM_DB_HOME** environment variable to a pre-installed **db2 client or server installation directory**.
-	- On z/OS, set **IBM_DB_HOME** environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSN1210.SDSNC.H` and `DSN1210.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSN1210` with the following statement (can be saved in `~/.profile`):
+	- On z/OS, set **IBM_DB_HOME** environment variable to the High Level Qualifier (HLQ) of your Db2 datasets.  For example, if your Db2 datasets are located as `DSNC10.SDSNC.H` and `DSNC10.SDSNMACS`, you need to set `IBM_DB_HOME` environment variable to `DSNC10` with the following statement (can be saved in `~/.profile`):
 
 
 `IBM_DB_INSTALLER_URL :`


### PR DESCRIPTION
Miscellaneous documentation updates for z/OS

- Add information about Db2 on z/OS PTF UI60551 that brings new ODBC functionality for Node.js applications.
- Update required settings information, specifically MULTICONTEXT=2 and FLOAT=IEEE in common section for z/OS ODBC initialization file.
- Update link to Marketplace page on where to get Node.js drivers for z/OS.
- Change DSN1210 to DSNC10 in documentation to better reflect standard z/OS Db2 dataset HLQ.

DCO 1.1 Signed-off-by: Joran Siu <joransiu@ca.ibm.com>