### PR TITLE
Enable ibm_db npm to work on node v12 on z/OS

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -16,6 +16,7 @@
 */
 #ifdef __MVS__
   #define _AE_BIMODAL
+  #include <_Nascii.h>
 #endif
 
 #include <string.h>
@@ -120,9 +121,14 @@ NAN_METHOD(ODBC::New)
 
   dbo->m_hEnv = (SQLHENV)NULL;
   
+  #ifdef __MVS__
+    int ori_mode = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  #endif
   // Initialize the Environment handle
   int ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &dbo->m_hEnv);
-  
+  #ifdef __MVS__
+    __ae_thread_swapmode(ori_mode);
+  #endif
   if (!SQL_SUCCEEDED(ret)) {
     DEBUG_PRINTF("ODBC::New - ERROR ALLOCATING ENV HANDLE!!\n");
     

--- a/test/test-basic-test.js
+++ b/test/test-basic-test.js
@@ -2,6 +2,7 @@ var common = require("./common")
     , ibmdb = require("../")
     , assert = require("assert")
     , cn = common.connectionString;
+var platform = require('os').platform();
 
 console.log("Trying to open a connection ... ");
 ibmdb.open(cn, {"fetchMode": 3}, function(err, conn) { // 3 means FETCH_ARRARY
@@ -12,7 +13,11 @@ ibmdb.open(cn, {"fetchMode": 3}, function(err, conn) { // 3 means FETCH_ARRARY
   try{
     conn.querySync("drop table mytab1");
   } catch (e) {}
-  conn.querySync("create table mytab1 (c1 int, c2 varchar(10))");
+  if (platform == 'os390') {
+    conn.querySync("create table mytab1 (c1 int, c2 varchar(10)) ccsid UNICODE");
+  } else {
+    conn.querySync("create table mytab1 (c1 int, c2 varchar(10))");
+  }
   conn.querySync("insert into mytab1 values ( 4, 'für')");
   conn.query('select 1, 4, 5 from sysibm.sysdummy1;', function (err, data) {
     if (err) {

--- a/test/test-multi-openSync-closeSync.js
+++ b/test/test-multi-openSync-closeSync.js
@@ -44,7 +44,7 @@ odbc.open(common.connectionString, function(err, conn) {
           console.log("result = ", result);
           conn.closeSync();
         }
-        assert(err['message'].search("SQL0204N") > 0);
+        assert(err['message'].search("SQL0204N|42704") > 0);
         console.log('Done');
         process.exit(errorCount);
     });


### PR DESCRIPTION
Changes to enable ibm_db npm to work on node v12 on z/OS, also modify some test cases to make them work correctly on odbc on z/OS