### PR TITLE
add invalid connections check for prepared statement

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -1326,6 +1326,7 @@ Database.prototype.prepare = function (sql, cb)
     }
 
     stmt.queue = new SimpleQueue();
+    stmt.db = self; // We need a reference to db to check for connection errors
 
     stmt.prepare(sql, function (err) 
     {
@@ -1360,6 +1361,7 @@ Database.prototype.prepareSync = function (sql)
   }
 
   stmt.queue = new SimpleQueue();
+  stmt.db = self; // We need a reference to db to check for connection errors
 
   try {
     stmt.prepareSync(sql);
@@ -1516,6 +1518,7 @@ odbc.ODBCStatement.prototype.execute = function (params, cb)
       exports.debug && console.log("%s odbc.js:execute() bind params = ", getElapsedTime(), params);
       self._bind(params, function (err) {
         if (err) {
+          self.db.checkConnectionError(err);
           if(!deferred)
           {
             cb(err);
@@ -1527,6 +1530,10 @@ odbc.ODBCStatement.prototype.execute = function (params, cb)
         }
 
         self._execute(function (err, result, outparams) {
+          if (err) {
+            self.db.checkConnectionError(err);
+          }
+
           if(!deferred)
           {
             cb(err, result, outparams);
@@ -1549,6 +1556,10 @@ odbc.ODBCStatement.prototype.execute = function (params, cb)
     else
     {
       self._execute(function (err, result, outparams) {
+        if (err) {
+          self.db.checkConnectionError(err);
+        }
+
         if(!deferred)
         {
           cb(err, result, outparams);

--- a/test/test-bad-pool-connection-prepare-execute.js
+++ b/test/test-bad-pool-connection-prepare-execute.js
@@ -1,0 +1,57 @@
+var common = require("./common")
+    , odbc = require("../lib/odbc")
+    , pool = new odbc.Pool()
+    , connectionString = common.connectionString
+    , assert = require("assert")
+    ;
+
+var i=0;
+console.log("---------------------------------------------------------------");
+console.log("After first iteration and before start of second iteration,");
+console.log("restart the server using 'db2stop force; db2start' command.");
+console.log("---------------------------------------------------------------");
+// odbc.debug(true);
+pool.setMaxPoolSize(5);
+var timer = setInterval(function() {
+    var j = i;
+    console.log('start' + j);
+    if(i == 3){
+        pool.close();
+        clearInterval(timer);
+    }
+
+    pool.open(connectionString, function (err, connection) {
+        if (err) {
+            console.log("Connection Error: " + err.toString());
+        }
+
+        connection.prepare("select * from sysibm.sysdummy1 WHERE IBMREQD <> ?", // IBMREQD is always 'Y'
+          function (err, stmt) {
+            if (err) {
+                assert.fail('should not error.');
+            }
+
+            stmt.execute(['0'], function (err, results) {
+                if (err) {
+                    console.log(err.toString());
+                    assert.equal(err['message'].search("SQL30081N"),18);
+                } else {
+                    const result = results.fetchAllSync();
+                    console.log(JSON.stringify(result));
+                    assert.equal(JSON.stringify(result), '[{"IBMREQD":"Y"}]');
+                }
+
+                connection.close(function () {
+                    console.log('Connection closed');
+                    console.log('done' + j);
+                    if (j == 0) {
+                        console.log("<=== Now restart the server using " + 
+                                    "'db2stop force; db2start' command. ====>");
+                    }
+                });
+            });
+        });
+    });
+    i++;
+}, 3000);  // Change it to 30000 when running single test file for actual test.
+


### PR DESCRIPTION
Recommit of #705 fixing the issue caused by it.

Original PR message:

This pull request adds checkConnectionError to errors in a prepared statement execution. (.execute). This fixes an issue where the Pool is not cleaned up when running prepared statements with invalid connections (e.g. after a db restart).

I made it after encountering this issue in one of my applications and based on what I read on #602 and #676 . In my case, prepare was not giving me errors, but execute did.

The test case is basically:
- Run a prepared statement -- it will work fine
- Restart the database (so your connections are now invalid)
- Run the prepared statement again -- it will fail during execute and the pool is now cleaned up
- Run the prepared statement again -- it will use a new and working connection