### PR TITLE
Electron 12 support for vs code.

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -22,7 +22,7 @@ var platform = os.platform();
 var arch = os.arch();
 
 var vscode_build = false;
-var electron_version = '11.2.1';
+var electron_version = '12.0.4';
 
 console.log("platform = ", platform, ", arch = ", arch, ", node.js version = ", process.version);
 
@@ -702,7 +702,10 @@ function findElectronVersion() {
           var codeOut = execSync('code --version').toString();
           vscodeVer = parseFloat(codeOut.split('\n')[0]);
           if(!isNaN(vscodeVer)) {
-            if (vscodeVer >= 1.53){
+            if (vscodeVer >= 1.56){
+                electron_version = "12.0.4";
+            }
+            else if (vscodeVer >= 1.53){
                 electron_version = "11.2.1";
             }
             else if (vscodeVer >= 1.52) {


### PR DESCRIPTION
This pull request has modified the existing driverinstaller.js file to support vscode >= 1.56.
And build.zip has additional Windows, Linux, and Mac binaries supporting electron 12.

Thanks,
Akhil