### PR TITLE
Added support for npm config SSL CA-files for driverInstall.js

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -4,6 +4,7 @@
 
 var fs = require('fs');
 var url = require('url');
+var https = require('https');
 var os = require('os');
 var path = require('path');
 var exec = require('child_process').exec;
@@ -37,6 +38,12 @@ if(process.env.npm_config_loglevel == 'silent') { // -silent option
 if(downloadProgress == 0) {
   printMsg("platform = " + platform + ", arch = " + arch +
            ", node.js version = " + process.version);
+}
+
+var httpsAgent;
+if (process.env.npm_config_cafile) {
+    const ca = fs.readFileSync(process.env.npm_config_cafile);
+    httpsAgent = new https.Agent({ ca });
 }
 
 /* Show make version on non-windows platform, if installed. */
@@ -648,7 +655,7 @@ var install_node_ibm_db = function(file_url) {
 
         var outStream = fs.createWriteStream(INSTALLER_FILE);
 
-        axios.get(installerfileURL, {responseType: 'stream'})
+        axios.get(installerfileURL, {responseType: 'stream', httpsAgent})
              .then(function (response) {
                 total_bytes = parseInt(response.headers['content-length']);
                 response.data.on('data', (chunk) => {


### PR DESCRIPTION
This commit contains a solution that fixes #856.

The updated `driverInstaller.js` retreives the value for the `cafile` option from the npm config (if it was specified), reads the content of the file and passes a httpsAgent with the according `ca` value.

The installation of the DB2 ODBC drivers through `npm run install` was tested successfully behind a company proxy with a certificate signed by a custom Root CA.

If the `cafile` option is not defined in the config, the variable `httpsAgent` passed to axios will be `undefined`. This is also a valid option for axios, as it is the default value for this parameter.