### PR TITLE
Fix error in driverInstaller on z/OS

### DIFF
--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -113,21 +113,15 @@ var install_node_ibm_db = function(file_url) {
     var clidriverFound = true;
 
     if (process.env.IBM_DB_HOME) {
-      if (platform == 'os390'){
-        IBM_DB_HOME = process.env.IBM_DB_HOME;
-        IS_ENVIRONMENT_VAR = true;
-	clidriverFound = true;
-      }else {
-        if (fs.existsSync(process.env.IBM_DB_HOME)) {
+        if (fs.existsSync(process.env.IBM_DB_HOME) || platform == "os390") {
           IBM_DB_HOME = process.env.IBM_DB_HOME;
           IS_ENVIRONMENT_VAR = true;
         } else {
-          printMsg(process.env.IBM_DB_HOME + " directory does not exist. Please " +
-                "check if you have set the IBM_DB_HOME environment" +
+          printMsg(process.env.IBM_DB_HOME + " directory does not exist. Please" +
+                " check if you have set the IBM_DB_HOME environment" +
                 " variable\'s value correctly.\n");
           clidriverFound = false;
         }
-      }
     }
 
     if (clidriverFound == false && fs.existsSync(DOWNLOAD_DIR + "/clidriver")){

--- a/installer/driverInstall.js
+++ b/installer/driverInstall.js
@@ -113,14 +113,20 @@ var install_node_ibm_db = function(file_url) {
     var clidriverFound = true;
 
     if (process.env.IBM_DB_HOME) {
-      if (fs.existsSync(process.env.IBM_DB_HOME)) {
+      if (platform == 'os390'){
         IBM_DB_HOME = process.env.IBM_DB_HOME;
         IS_ENVIRONMENT_VAR = true;
-      } else {
-      printMsg(process.env.IBM_DB_HOME + " directory does not exist. Please " +
-            "check if you have set the IBM_DB_HOME environment" +
-            " variable\'s value correctly.\n");
-      clidriverFound = false;
+	clidriverFound = true;
+      }else {
+        if (fs.existsSync(process.env.IBM_DB_HOME)) {
+          IBM_DB_HOME = process.env.IBM_DB_HOME;
+          IS_ENVIRONMENT_VAR = true;
+        } else {
+          printMsg(process.env.IBM_DB_HOME + " directory does not exist. Please " +
+                "check if you have set the IBM_DB_HOME environment" +
+                " variable\'s value correctly.\n");
+          clidriverFound = false;
+        }
       }
     }
 


### PR DESCRIPTION
This fixes a build issue on z/OS.  

The installer should not check if IBM_DB_HOME folder exists on z/OS as that path represents a HLQ dataset, not a DB2 installation.