### PR TITLE
Fix calling FreeColumns multiple times resulting in SIGABRT

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -393,7 +393,7 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount)
  * FreeColumns
  */
 
-void ODBC::FreeColumns(Column* columns, short* colCount)
+void ODBC::FreeColumns(Column* &columns, short* colCount)
 {
   DEBUG_PRINTF("ODBC::FreeColumns - Entry\n");
   for(int i = 0; i < *colCount; i++) {

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -129,7 +129,7 @@ class ODBC : public Nan::ObjectWrap {
 
     static NAN_MODULE_INIT(Init);
     static Column* GetColumns(SQLHSTMT hStmt, short* colCount);
-    static void FreeColumns(Column* columns, short* colCount);
+    static void FreeColumns(Column* &columns, short* colCount);
     static v8::Local<Value> GetColumnValue(SQLHSTMT hStmt, Column column, uint16_t* buffer, size_t bufferLength);
     static Local<Value> GetOutputParameter(Parameter *prm);
     static Local<Object> GetRecordTuple (SQLHSTMT hStmt, Column* columns, short* colCount, uint16_t* buffer, size_t bufferLength);


### PR DESCRIPTION
Calling the method `FreeColumns`multiple times results in a SIGABRT.

One way to invoke this behaviour is by first calling `fetchAll`and then `getColumnMetadataSync` as shown in the example below:
```
const conn = new Database()
await conn.open(connectionString)
const stmt = await conn.prepare(`SELECT * from "users" WHERE "username" = 'jan' FETCH NEXT 1 ROWS ONLY FOR UPDATE`)
stmt.execute([], async (err, result, outparams) => {
    await result.fetchAll();
    await result.getColumnMetadataSync();
})
```

I've proposed a fix, where we provide `FreeColumns` with a reference to the column pointer instead. This way, `FreeColumns` can set the pointer to `NULL` once it's deleted.