### PR TITLE
Fix callback typing for `ibm_db.open`

### DIFF
--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -27,11 +27,11 @@ export function debug(): any {}
 export function open(
   connStr: string | ConnStr,
   options: Options | null,
-  cb?: (err: Error, db: Database) => void
+  cb: (err: Error, db: Database) => void
 ): void;
 export function open(
   connStr: string | ConnStr,
-  cb?: (err: Error, db: Database) => void
+  cb: (err: Error, db: Database) => void
 ): void;
 export function open(
   connStr: string | ConnStr,


### PR DESCRIPTION
This PR fixes the typing for `ibm_db.open` marking `cb` (callback) required for the overloads that uses callback.

This allows TypeScript to properly identify whether you are using the callback or promise version, as explained here: https://github.com/ibmdb/node-ibm_db/pull/1022#discussion_r2231776976

Quick example:

```
const conn = await ibm_db.open('str'); //<-- Error, 'awaiting void'
// This happens because it could either mean open(string) or open(string, function|undefined) from callback
```

the code itself only runs the callback if a callback is provided, thus, the correct typing is to make callback required:
```
open(string!): Promise<Database>; //<-- no callback, promise returned
open(string!, function!): void; //<-- callback, void return
```
