### PR TITLE
Upgrade to axios@1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "ibm_db",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",
-        "axios": "^1.11.0",
+        "axios": "^1.12.0",
         "big-integer": "^1.6.51",
         "bindings": "^1.5.0",
         "fs-extra": "^11.1.1",
@@ -61,9 +61,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -618,9 +619,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.5.16",
-    "axios": "^1.11.0",
+    "axios": "^1.12.0",
     "big-integer": "^1.6.51",
     "bindings": "^1.5.0",
     "fs-extra": "^11.1.1",


### PR DESCRIPTION
# Upgrade to axios v1.12.0

`axios@1.11.0` carries [CVE-2025-58754](https://github.com/advisories/GHSA-4hjh-wcwx-xvwj), exposing usage to a DoS attack. This PR upgrades axios to v1.12.0, fixing the CVE.

## Developer's Certificate of Origin 1.1

DCO Signed-off-by: Sebastian Wilczek <sebastian.wilczek@ibm.com>

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.