### PR TITLE
Upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "big-integer": "^1.6.51",
         "bindings": "^1.5.0",
         "fs-extra": "^11.1.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "node-addon-api": "^7.1.1",
         "targz": "^1.0.1"
       },
@@ -394,9 +394,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -889,9 +890,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "big-integer": "^1.6.51",
     "bindings": "^1.5.0",
     "fs-extra": "^11.1.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "node-addon-api": "^7.1.1",
     "targz": "^1.0.1"
   },


### PR DESCRIPTION
# Upgrade to lodash v4.18.1

`lodash@^4.17.21` carries CVE-2026-4800. This PR upgrades lodash to v14.18.1, fixing the CVE.

## Developer's Certificate of Origin 1.1

DCO Signed-off-by: Sebastian Wilczek <sebastian.wilczek@ibm.com>

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.