### PR TITLE
coerce a bind parameter to a string once and stop when the coercion fails

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -787,6 +787,11 @@ Parameter *ODBC::GetParametersFromArray(Napi::Env env, Napi::Array values, int *
     {
       GetBoolParam(env, value, &params[i], i + 1);
     }
+
+    if (env.IsExceptionPending())
+    {
+      return params;
+    }
   }
   return params;
 }
@@ -797,6 +802,12 @@ void ODBC::GetStringParam(Napi::Env env, Napi::Value value, Parameter *param, in
   int bufflen = 0;
   int terCharLen = 1;
   bool isBinary = (param->c_type == SQL_C_BINARY);
+
+  Napi::String stringValue = value.ToString();
+  if (stringValue.IsEmpty())
+  {
+    return;
+  }
 
   // Determine string length using encoding that matches NAN behavior:
   // SQL_C_BINARY -> Latin-1 (WriteOneByte), UNICODE -> UTF-16 (Write), else -> UTF-8
@@ -813,7 +824,7 @@ void ODBC::GetStringParam(Napi::Env env, Napi::Value value, Parameter *param, in
   }
 #else
   else {
-    std::string utf8str = value.ToString().Utf8Value();
+    std::string utf8str = stringValue.Utf8Value();
     length = (int)utf8str.length();
   }
 #endif
@@ -834,7 +845,7 @@ void ODBC::GetStringParam(Napi::Env env, Napi::Value value, Parameter *param, in
     param->type = (length >= 8000) ? SQL_LONGVARCHAR : SQL_VARCHAR;
   if (!isBinary)
   {
-    std::string utf8str = value.ToString().Utf8Value();
+    std::string utf8str = stringValue.Utf8Value();
     bufflen = (int)utf8str.length() + 1;
     param->length = bufflen - 1;
   }
@@ -855,7 +866,7 @@ void ODBC::GetStringParam(Napi::Env env, Napi::Value value, Parameter *param, in
   // Copy string data using correct encoding (matching NAN behavior)
   if (param->paramtype == FILE_PARAM) {
     // FILE_PARAM: use UTF-8 (matches NAN's WriteUtf8)
-    std::string utf8str = value.ToString().Utf8Value();
+    std::string utf8str = stringValue.Utf8Value();
     memcpy(param->buffer, utf8str.c_str(), utf8str.length());
   } else if (isBinary) {
     // SQL_C_BINARY: use Latin-1 (matches NAN's WriteOneByte)
@@ -868,7 +879,7 @@ void ODBC::GetStringParam(Napi::Env env, Napi::Value value, Parameter *param, in
     napi_get_value_string_utf16(env, value, (char16_t *)param->buffer, length + 1, &copied);
 #else
     // Non-UNICODE text: use UTF-8 (matches NAN's WriteUtf8)
-    std::string utf8str = value.ToString().Utf8Value();
+    std::string utf8str = stringValue.Utf8Value();
     memcpy(param->buffer, utf8str.c_str(), utf8str.length());
 #endif
   }
@@ -1154,6 +1165,7 @@ void ODBC::GetArrayParam(Napi::Env env, Napi::Value value, Parameter *param, int
         else
         {
           GetStringParam(env, val, param, num);
+          if (env.IsExceptionPending()) break;
 #ifdef UNICODE
           param->buffer_length -= 2;
 #else


### PR DESCRIPTION
### Summary

`ODBC::GetStringParam` converts a bind parameter with `value.ToString().Utf8Value()`. The addon is built with `NAPI_DISABLE_CPP_EXCEPTIONS`, so when `ToString()` fails, it does not throw a catchable C++ exception. It returns an *empty handle* and leaves a JS exception pending, and execution continues. `Utf8Value()` on that empty handle is a second failing Node-API call while an exception is pending, which node-addon-api reports through `napi_fatal_error`, leading to a SIGABRT.

### Environment

- Node v22.14.0, Linux x64

### Reproducer

```js
const conn = new (require('ibm_db').Database)().odbc.createConnectionSync();
conn.querySync('values 1', [ [0, 0, 0, { toString: 1 }] ]);   // -> SIGABRT, exit 134
```

`{toString: 1}`, `Object.create(null)`, a `Symbol`, and any object whose `toString` throws all trigger it.

This leads to:

```
FATAL ERROR: Error::New napi_get_last_error_info
----- Native stack trace -----

 1: 0xe3605b node::OnFatalError(char const*, char const*) [node]
 2: 0xf500a5  [node]
 3: 0x7f97d46e0b8a  [ibm_db/build/Release/odbc_bindings.node]
 4: 0x7f97d46e0e95 Napi::Error::New(napi_env__*) [ibm_db/build/Release/odbc_bindings.node]
 5: 0x7f97d46e48c4 Napi::String::Utf8Value[abi:cxx11]() const [ibm_db/build/Release/odbc_bindings.node]
 6: 0x7f97d46d9f85 ODBC::GetStringParam(Napi::Env, Napi::Value, Parameter*, int) [ibm_db/build/Release/odbc_bindings.node]
 7: 0x7f97d46dc960 ODBC::GetParametersFromArray(Napi::Env, Napi::Array, int*) [ibm_db/build/Release/odbc_bindings.node]
 8: 0x7f97d46edac6 ODBCConnection::QuerySync(Napi::CallbackInfo const&) [ibm_db/build/Release/odbc_bindings.node]
 9: 0x7f97d46f1487 Napi::InstanceWrap<ODBCConnection>::InstanceMethodCallbackWrapper(napi_env__*, napi_callback_info__*) [ibm_db/build/Release/odbc_bindings.node]
10: 0xf25025  [node]
11: 0x7f97cddcf5e2 
```