### PR TITLE
type-tag ODBCStatement and verify the tag before unwrapping in cancel

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1635,6 +1635,12 @@ Napi::Value ODBCConnection::Cancel(const Napi::CallbackInfo &info)
   Napi::Object stmtObj = info[0].As<Napi::Object>();
   Napi::Function cb = info[1].As<Napi::Function>();
 
+  if (!stmtObj.CheckTypeTag(&ODBC_STATEMENT_TYPE_TAG))
+  {
+    Napi::TypeError::New(env, "cancel() requires an ODBCStatement object").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
   napi_status status;
   ODBCStatement *stmt = nullptr;
   status = napi_unwrap(env, stmtObj, reinterpret_cast<void**>(&stmt));
@@ -1717,6 +1723,13 @@ Napi::Value ODBCConnection::CancelSync(const Napi::CallbackInfo &info)
   }
 
   Napi::Object stmtObj = info[0].As<Napi::Object>();
+
+  if (!stmtObj.CheckTypeTag(&ODBC_STATEMENT_TYPE_TAG))
+  {
+    Napi::TypeError::New(env, "cancelSync() requires an ODBCStatement object").ThrowAsJavaScriptException();
+    return Napi::Boolean::New(env, false);
+  }
+
   napi_status status;
   ODBCStatement *stmt = nullptr;
   status = napi_unwrap(env, stmtObj, reinterpret_cast<void**>(&stmt));

--- a/src/odbc_statement.cpp
+++ b/src/odbc_statement.cpp
@@ -102,6 +102,8 @@ ODBCStatement::ODBCStatement(const Napi::CallbackInfo &info) : Napi::ObjectWrap<
   m_hDBC = (SQLHDBC)((intptr_t)info[1].As<Napi::External<void>>().Data());
   m_hSTMT = (SQLHSTMT)((intptr_t)info[2].As<Napi::External<void>>().Data());
 
+  Value().TypeTag(&ODBC_STATEMENT_TYPE_TAG);
+
   bufferLength = MAX_VALUE_SIZE;
   buffer = NULL;
   colCount = 0;

--- a/src/odbc_statement.h
+++ b/src/odbc_statement.h
@@ -19,6 +19,9 @@
 
 #include <napi.h>
 
+static constexpr napi_type_tag ODBC_STATEMENT_TYPE_TAG = {
+    0x4f8c1a6b3d92e705ULL, 0xb17e05c8fa63d249ULL};
+
 class ODBCStatement : public Napi::ObjectWrap<ODBCStatement>
 {
 public:


### PR DESCRIPTION
### Summary

`ODBCConnection::Cancel` and `ODBCConnection::CancelSync` check only that their argument is an object, then `napi_unwrap` it into an `ODBCStatement*` and immediately read `stmt->m_hSTMT`:

```cpp
// src/odbc_connection.cpp:1722
napi_unwrap(env, stmtObj, reinterpret_cast<void**>(&stmt));
// src/odbc_connection.cpp:1724
if (status != napi_ok || !stmt || !stmt->m_hSTMT)
// src/odbc_connection.cpp:1732
SQLRETURN ret = SQLCancel(hSTMT);
```

`napi_unwrap` returns whatever pointer `napi_wrap` stored and carries no C++ type information, so **every** object this addon wrapped is accepted, such as a connection,  an `ODBCResult` or whatever other object containing a napi_wrap. The memory of those arbitrary objects is then reinterpreted as an `ODBCStatement`. Then, whatever is found at `m_hSTMT` offset is then passed to `SQLCancel` as a statement handle.


### Reproduction

```js
const ibmdb = require('ibm_db');
const conn = new ibmdb.Database().odbc.createConnectionSync();

conn.systemNaming = false;
try { conn.cancelSync(conn); } catch (e) { console.log('systemNaming=false ->', e.message); }

conn.systemNaming = true;
try { conn.cancelSync(conn); } catch (e) { console.log('systemNaming=true  ->', e.message); }
```
`systemNaming` is an ordinary boolean property of the connection. It changes the outcome of `cancelSync`. The second call reaches the driver on a handle the script chose.

Note that the same read can also segfault, since `stmt` is dereferenced before it is validated. For example, you may give `cancel` an object whose stored pointer is not backed by memory, and `odbc_connection.cpp:1724` segfaults before `SQLCancel` is ever reached.

### Fix

Stamp a Node-API type tag on every `ODBCStatement` and check it before unwrapping.

After this fix, the package will throw a TypeRrror that the input object is not an `ODBCStatement`.